### PR TITLE
Use a different name for local transpose replacement

### DIFF
--- a/src/1.JWAS/src/MCMC/MT_MCMC_BayesB.jl
+++ b/src/1.JWAS/src/MCMC/MT_MCMC_BayesB.jl
@@ -115,7 +115,7 @@ function MT_MCMC_BayesB(nIter,mme,df,Pi;
 
             outfile[traiti]=open(file_name,"w")
             if mme.M.markerID[1]!="NA"
-              writedlm(outfile[traiti],transpose(mme.M.markerID))
+              writedlm(outfile[traiti],transubstrarr(mme.M.markerID))
             end
         end
     end

--- a/src/1.JWAS/src/MCMC/MT_MCMC_BayesC.jl
+++ b/src/1.JWAS/src/MCMC/MT_MCMC_BayesC.jl
@@ -142,7 +142,7 @@ function MT_MCMC_BayesC(nIter,mme,df;
 
           outfile[traiti]=open(file_name,"w")
           if mme.M.markerID[1]!="NA"
-              writedlm(outfile[traiti],transpose(mme.M.markerID))
+              writedlm(outfile[traiti],transubstrarr(mme.M.markerID))
           end
         end
       end

--- a/src/1.JWAS/src/MCMC/outputMCMCsamples.jl
+++ b/src/1.JWAS/src/MCMC/outputMCMCsamples.jl
@@ -32,7 +32,7 @@ function output_MCMC_samples_setup(mme,nIter,output_samples_frequency,ismarker=t
     outfile=open(file_name,"w")
 
     if mme.M.markerID[1]!="NA"
-        writedlm(outfile,transpose(mme.M.markerID))
+        writedlm(outfile,transubstrarr(mme.M.markerID))
     end
     pi = zeros(num_samples)#vector to save π (for BayesC)
     return out_i,outfile,pi
@@ -116,7 +116,7 @@ function outputSamples(mme::MME,sol,iter::Int64)
 end
 
 #function to replace Array{SubString{String}' for issue 8
-function transpose(vec::Array{SubString{String},1})
+function transubstrarr(vec::Array{SubString{String},1})
     lvec=length(vec)
     res =Array(String,1,lvec)
     for i in 1:lvec


### PR DESCRIPTION
just to avoid the possibility of name clashes

this isn't imported from Base right now but if it was, it would be
type piracy - extending Base functions on Base types - which is recommended against