### PR TITLE
Fix tests on Julia 1.4: narrow element type of vv vector to fix test error on Julia 1.4

### DIFF
--- a/src/1.JWAS/src/buildMME/residual.jl
+++ b/src/1.JWAS/src/buildMME/residual.jl
@@ -43,6 +43,8 @@ function mkRi(mme::MME,df::DataFrame)
         end
     end
     mme.resVar = resVar
+    # This narrows the element type of the vv vector
+    vv = map(identity, vv)
     return sparse(ii,jj,vv)
 end
 


### PR DESCRIPTION
While testing packages for the upcoming Julia 1.4 we found that this package tests errored. The reason boils down to the following difference:

```
julia> using SparseArrays

julia> a = convert(SparseMatrixCSC{AbstractFloat, Int}, sparse(rand(Float32, 2,2)));

julia> b = sparse(rand(Float32, 2,2));

julia> typeof(a*b)
SparseMatrixCSC{Any,Int64}
```

In 1.3, the resulting type was a `SparseMatrixCSC{AbstractFloat,Int64}`.

This PR fixes the test error by "narrowing" the element type of `vv` (so if it only contains e.g. `Float32`s, `vv` will become a `Vector{Float32}` instead of a `Vector{AbstractFloat}`).

Disregarding the change in 1.4, this is likely to be better since it will give a concrete element type to the sparse matrix in most cases which will make future operations with it more efficient.