### PR TITLE
call into generix axpy! intead of the BLAS specific one

### DIFF
--- a/src/0.deprecated/BayesCDom.jl
+++ b/src/0.deprecated/BayesCDom.jl
@@ -26,13 +26,13 @@ function sampleEffectsBayesCDom!(yCorr, nObs, nMarkers, xArray, XpRinvX, markerM
         probDelta1::Float64 = 1.0/(1.0 + exp(logDelta0[1] - logDelta1))
         if (rand() < probDelta1)
             a[j] = gHat + randn()*sqrt(invLhs)
-            BLAS.axpy!(olda-a[j],x,yCorr)
-            BLAS.axpy!(a[j],x,gj)
+            axpy!(olda-a[j],x,yCorr)
+            axpy!(a[j],x,gj)
             nAddEff = nAddEff + 1
             δ[j,1] = 1
         else
             if (δ[j,1]!=0)
-                BLAS.axpy!(olda,x,yCorr)
+                axpy!(olda,x,yCorr)
             end
             a[j] = 0
             δ[j,1] = 0
@@ -52,13 +52,13 @@ function sampleEffectsBayesCDom!(yCorr, nObs, nMarkers, xArray, XpRinvX, markerM
         probDelta1 = 1.0/(1.0 + exp(logDelta0[2] - logDelta1))
         if (rand() < probDelta1)
             d[j] = gHat + randn()*sqrt(invLhs)
-            BLAS.axpy!(oldd-d[j],w,yCorr)
-            BLAS.axpy!(d[j],w,gj)
+            axpy!(oldd-d[j],w,yCorr)
+            axpy!(d[j],w,gj)
             nDomEff = nDomEff + 1
             δ[j,2] = 1
         else
             if (δ[j,2]!=0)
-                BLAS.axpy!(oldd,w,yCorr)
+                axpy!(oldd,w,yCorr)
             end
             d[j] = 0
             δ[j,2] = 0
@@ -67,15 +67,15 @@ function sampleEffectsBayesCDom!(yCorr, nObs, nMarkers, xArray, XpRinvX, markerM
         # estimate substitution effect by OLS
         if (a[j]!=0 && d[j]==0)
             α[j] = a[j]
-            BLAS.axpy!(1,gj,g)
-            BLAS.axpy!(1,gj,u)
+            axpy!(1,gj,g)
+            axpy!(1,gj,u)
         elseif (a[j]==0 && d[j]!=0)
             α[j] = 0
-            BLAS.axpy!(1,gj,g)
+            axpy!(1,gj,g)
         elseif (a[j]!=0 && d[j]!=0)
             α[j] = dot(x,gj-mean(gj))/dot(x,x)
-            BLAS.axpy!(1,gj,g)
-            BLAS.axpy!(α[j],x,u)
+            axpy!(1,gj,g)
+            axpy!(α[j],x,u)
         else
             α[j] = 0
         end
@@ -235,4 +235,3 @@ function BayesCDom!(options,X,y,C,Rinv)
 
     return output
 end
-

--- a/src/0.deprecated/BayesCPiDom.jl
+++ b/src/0.deprecated/BayesCPiDom.jl
@@ -28,13 +28,13 @@ function sampleEffectsBayesCPiDom!(yCorr, nObs, nMarkers, xArray, XpRinvX, marke
         probDelta1::Float64 = 1.0/(1.0 + exp(logDelta0[1] - logDelta1))
         if (rand() < probDelta1)
             a[j] = gHat + randn()*sqrt(invLhs)
-            BLAS.axpy!(olda-a[j],x,yCorr)
-            BLAS.axpy!(a[j],x,gj)
+            axpy!(olda-a[j],x,yCorr)
+            axpy!(a[j],x,gj)
             nAddEff = nAddEff + 1
             δ[j,1] = 1
         else
             if (δ[j,1]!=0)
-                BLAS.axpy!(olda,x,yCorr)
+                axpy!(olda,x,yCorr)
             end
             a[j] = 0
             δ[j,1] = 0
@@ -54,13 +54,13 @@ function sampleEffectsBayesCPiDom!(yCorr, nObs, nMarkers, xArray, XpRinvX, marke
         probDelta1 = 1.0/(1.0 + exp(logDelta0[2] - logDelta1))
         if (rand() < probDelta1)
             d[j] = gHat + randn()*sqrt(invLhs)
-            BLAS.axpy!(oldd-d[j],w,yCorr)
-            BLAS.axpy!(d[j],w,gj)
+            axpy!(oldd-d[j],w,yCorr)
+            axpy!(d[j],w,gj)
             nDomEff = nDomEff + 1
             δ[j,2] = 1
         else
             if (δ[j,2]!=0)
-                BLAS.axpy!(oldd,w,yCorr)
+                axpy!(oldd,w,yCorr)
             end
             d[j] = 0
             δ[j,2] = 0
@@ -69,15 +69,15 @@ function sampleEffectsBayesCPiDom!(yCorr, nObs, nMarkers, xArray, XpRinvX, marke
         # estimate substitution effect by OLS
         if (a[j]!=0 && d[j]==0)
             α[j] = a[j]
-            BLAS.axpy!(1,gj,g)
-            BLAS.axpy!(1,gj,u)
+            axpy!(1,gj,g)
+            axpy!(1,gj,u)
         elseif (a[j]==0 && d[j]!=0)
             α[j] = 0
-            BLAS.axpy!(1,gj,g)
+            axpy!(1,gj,g)
         elseif (a[j]!=0 && d[j]!=0)
             α[j] = dot(x,gj-mean(gj))/dot(x,x)
-            BLAS.axpy!(1,gj,g)
-            BLAS.axpy!(α[j],x,u)
+            axpy!(1,gj,g)
+            axpy!(α[j],x,u)
         else
             α[j] = 0
         end
@@ -224,4 +224,3 @@ function BayesCPiDom!(options,X,y,C,Rinv)
 
     return output
 end
-

--- a/src/0.deprecated/BayesN.jl
+++ b/src/0.deprecated/BayesN.jl
@@ -38,7 +38,7 @@ function sampleEffectsBayesN!(yCorr, nObs, nWindows, windows, windowSizes, xArra
         probDelta1 = 1.0/(1.0 + exp(logDelta0ToDelta1))
         if (rand() < probDelta1)
             if (Δ[i]==0)
-                BLAS.axpy!(-1,windowEffect,yCorr)
+                axpy!(-1,windowEffect,yCorr)
             end
             Δ[i] = 1
             π = (windowSizes[i] - k)/windowSizes[i]
@@ -168,4 +168,3 @@ function BayesN!(options,X,y,C,Rinv)
 
     return output
 end
-

--- a/src/0.deprecated/MCMC_BayesCC.jl
+++ b/src/0.deprecated/MCMC_BayesCC.jl
@@ -333,7 +333,7 @@ function sampleMarkerEffectsBayesCC!(xArray,xpx,wArray,alphaArray,meanAlphaArray
 
         # adjust for locus j
         for trait = 1:ntraits
-            BLAS.axpy!(oldu[trait]-newu[trait],x,wArray[trait])
+            axpy!(oldu[trait]-newu[trait],x,wArray[trait])
             meanAlphaArray[trait][j] += (α[trait] - meanAlphaArray[trait][j])/iIter
             meanDeltaArray[trait][j] += (δ[trait] - meanDeltaArray[trait][j])/iIter
             meanuArray[trait][j]     += (newu[trait] - meanuArray[trait][j])/iIter

--- a/src/0.deprecated/Tools.jl
+++ b/src/0.deprecated/Tools.jl
@@ -20,7 +20,7 @@ end
 function center!(X)
     nrow,ncol = size(X)
     colMeans = mean(X,1)
-    BLAS.axpy!(-1,ones(nrow)*colMeans,X)
+    axpy!(-1,ones(nrow)*colMeans,X)
     return colMeans
 end
 
@@ -41,5 +41,3 @@ function get_dom_cov(x, n)  # create dominance covariates from additive covariat
     end
     return w
 end
-
-

--- a/src/1.JWAS/src/markers/BayesianAlphabet/BayesABC.jl
+++ b/src/1.JWAS/src/markers/BayesianAlphabet/BayesABC.jl
@@ -40,10 +40,10 @@ function BayesABC!(xArray,xRinvArray,xpRinvx,
             δ[j] = 1
             β[j] = gHat + randn()*sqrt(invLhs)
             α[j] = β[j]
-            BLAS.axpy!(oldAlpha-α[j],x,yCorr)
+            axpy!(oldAlpha-α[j],x,yCorr)
         else
             if (oldAlpha!=0)
-                BLAS.axpy!(oldAlpha,x,yCorr)
+                axpy!(oldAlpha,x,yCorr)
             end
             δ[j] = 0
             β[j] = randn()*sqrt(varEffects[j])

--- a/src/1.JWAS/src/markers/BayesianAlphabet/BayesC0L.jl
+++ b/src/1.JWAS/src/markers/BayesianAlphabet/BayesC0L.jl
@@ -42,6 +42,6 @@ function BayesL!(xArray,xRinvArray,xpRinvx,
         mean     = invLhs*rhs
         oldAlpha = α[j]
         α[j]     = mean + randn()*sqrt(invLhs*vRes)
-        BLAS.axpy!(oldAlpha-α[j],x,yCorr)
+        axpy!(oldAlpha-α[j],x,yCorr)
     end
 end

--- a/src/1.JWAS/src/markers/BayesianAlphabet/MTBayesABC.jl
+++ b/src/1.JWAS/src/markers/BayesianAlphabet/MTBayesABC.jl
@@ -70,13 +70,13 @@ function MTBayesABC!(xArray,xRinvArray,xpRinvx,
             if(rand()<probDelta1)
                 δ[k] = 1
                 β[k] = newα[k] = gHat1 + randn()*sqrt(invLhs1)
-                BLAS.axpy!(oldα[k]-newα[k],x,wArray[k])
+                axpy!(oldα[k]-newα[k],x,wArray[k])
             else
                 β[k] = gHat0 + randn()*sqrt(invLhs0)
                 δ[k] = 0
                 newα[k] = 0
                 if oldα[k] != 0
-                    BLAS.axpy!(oldα[k],x,wArray[k])
+                    axpy!(oldα[k],x,wArray[k])
                 end
             end
         end
@@ -173,7 +173,7 @@ function MTBayesABC_samplerII!(xArray,
 
         # adjust for locus j
         for trait in 1:ntraits
-            BLAS.axpy!(oldα[trait]-newα[trait],x,wArray[trait])  #update wArray (ycorr)
+            axpy!(oldα[trait]-newα[trait],x,wArray[trait])  #update wArray (ycorr)
             betaArray[trait][marker]       = β[trait]
             deltaArray[trait][marker]      = δ[trait]
             alphaArray[trait][marker]      = newα[trait]

--- a/src/1.JWAS/src/markers/BayesianAlphabet/MTBayesC0L.jl
+++ b/src/1.JWAS/src/markers/BayesianAlphabet/MTBayesC0L.jl
@@ -45,7 +45,7 @@ function MTBayesL!(xArray,xRinvArray,xpRinvx,
             newα[trait] = alphaArray[trait][marker]
         end
         for trait = 1:ntraits
-            BLAS.axpy!(oldα[trait]-newα[trait],x,wArray[trait])
+            axpy!(oldα[trait]-newα[trait],x,wArray[trait])
         end
     end
 end

--- a/src/1.JWAS/src/markers/BayesianAlphabet/MTBayesCC_deprecated.jl
+++ b/src/1.JWAS/src/markers/BayesianAlphabet/MTBayesCC_deprecated.jl
@@ -80,7 +80,7 @@ function sampleMarkerEffectsBayesCC!(xArray,xpx,wArray,alphaArray,
 
         # adjust for locus j
         for trait = 1:ntraits
-            BLAS.axpy!(oldu[trait]-newu[trait],x,wArray[trait])
+            axpy!(oldu[trait]-newu[trait],x,wArray[trait])
             alphaArray[trait][marker]      = α[trait]
             deltaArray[trait][marker]      = δ[trait]
             uArray[trait][marker]          = newu[trait]

--- a/src/1.JWAS/src/markers/tools4genotypes.jl
+++ b/src/1.JWAS/src/markers/tools4genotypes.jl
@@ -21,7 +21,7 @@ end
 function center!(X)
     nrow     = size(X,1)
     colMeans = mean(X,dims=1)
-    BLAS.axpy!(-1,ones(nrow)*colMeans,X)
+    axpy!(-1,ones(nrow)*colMeans,X)
     return colMeans
 end
 


### PR DESCRIPTION
`BLAS.axpy!` and `LinearAlgebra.axpy!` (the generic version) were separated in https://github.com/JuliaLang/julia/pull/44758 since calls to `BLAS.axpy!` did not always call into BLAS. This made this package break since it is calling `BLAS.axpy!` with element types that BLAS do not support. Just calling `axpy!` fixes this.