### PR TITLE
typo in printing

### DIFF
--- a/src/1.JWAS/src/JWAS.jl
+++ b/src/1.JWAS/src/JWAS.jl
@@ -576,7 +576,9 @@ function getMCMCinfo(mme)
         @printf("%-30s %20.3f\n","polygenic effect variances:",mme.df.polygenic)
     end
     if mme.M!=0
-        @printf("%-30s %20.3f\n","marker effect variances:",mme.df.marker)
+        for Mi in mme.M
+            @printf("%-30s %20.3f\n","marker effect variances:",Mi.df)
+        end
     end
     @printf("\n\n\n")
 end


### PR DESCRIPTION
typo in printing information for df of marker effect:
print `Mi.df` for each genotype, instead of `mme.df.marker`, which is not used in JWAS.
ST: Mi.df=4, MT: Mi.df=4+ntraits.