### PR TITLE
add variance module

### DIFF
--- a/src/1.JWAS/src/JWAS.jl
+++ b/src/1.JWAS/src/JWAS.jl
@@ -340,15 +340,12 @@ function runMCMC(mme::MME,df;
         mme.Gi = map(Float64,mme.Gi)
     end
 
-
-
-
-    #constraint on covariance matrix: modify df and scale
+    #constraint on covariance matrix
     if mme.R.constraint==true
-      R_constraint!(mme)
+        R_constraint!(mme) #modify mme.R.df and mme.R.scale; scale is a diagonal matrix
     end
     if mme.M[1].G.constraint==true
-        G_constraint!(mme)
+        G_constraint!(mme) #modify Mi.G.df and Mi.G.scale; scale is a diagonal matrix
     end
 
     # NNBayes: modify parameters for partial connected NN
@@ -520,11 +517,11 @@ function getMCMCinfo(mme)
         end
     end
     if mme.pedTrmVec!=0
-        polygenic_pos = findfirst(i -> i.randomType=="A", mme.rndTrmVec)
+        polygenic_pos = findfirst(i -> i.randomType=="A", mme.rndTrmVec) #print all polygenic models terms?
     end
     if mme.pedTrmVec!=0
         @printf("%-30s\n","genetic variances (polygenic):")
-        Base.print_matrix(stdout,round.(inv(mme.rndTrmVec[polygenic_pos].Gi.val),digits=3))
+        Base.print_matrix(stdout,round.(inv(mme.rndTrmVec[polygenic_pos].Gi.val),digits=3)) #print all polygenic models terms?
         println()
     end
     if mme.nModels == 1

--- a/src/1.JWAS/src/JWAS.jl
+++ b/src/1.JWAS/src/JWAS.jl
@@ -517,11 +517,11 @@ function getMCMCinfo(mme)
         end
     end
     if mme.pedTrmVec!=0
-        polygenic_pos = findfirst(i -> i.randomType=="A", mme.rndTrmVec) #print all polygenic models terms?
+        polygenic_pos = findfirst(i -> i.randomType=="A", mme.rndTrmVec)
     end
     if mme.pedTrmVec!=0
         @printf("%-30s\n","genetic variances (polygenic):")
-        Base.print_matrix(stdout,round.(inv(mme.rndTrmVec[polygenic_pos].Gi.val),digits=3)) #print all polygenic models terms?
+        Base.print_matrix(stdout,round.(inv(mme.rndTrmVec[polygenic_pos].Gi.val),digits=3))
         println()
     end
     if mme.nModels == 1

--- a/src/1.JWAS/src/MCMC/MCMC_BayesianAlphabet.jl
+++ b/src/1.JWAS/src/MCMC/MCMC_BayesianAlphabet.jl
@@ -14,10 +14,8 @@ function MCMC_BayesianAlphabet(mme,df)
     has_binary_trait         = "categorical(binary)" ∈ mme.traits_type
     has_censored_trait       = "censored"            ∈ mme.traits_type
     missing_phenotypes       = mme.MCMCinfo.missing_phenotypes
-    # constraint               = mme.MCMCinfo.constraint
     causal_structure         = mme.causal_structure
     is_multi_trait           = mme.nModels != 1
-    # is_mega_trait            = mme.R.constraint==true && mme.M[1].G.constraint==true #is_mega_trait when no residual and marker effect covariances 
     is_nnbayes_partial       = mme.nonlinear_function != false && mme.is_fully_connected==false
     is_activation_fcn        = mme.is_activation_fcn
     nonlinear_function       = mme.nonlinear_function
@@ -204,7 +202,6 @@ function MCMC_BayesianAlphabet(mme,df)
                 if Mi.method in ["BayesC","BayesB","BayesA"]
                     locus_effect_variances = (Mi.method == "BayesC" ? fill(Mi.G.val,Mi.nMarkers) : Mi.G.val)
                     if is_multi_trait && !is_nnbayes_partial
-                        # if is_mega_trait
                         if Mi.G.constraint==true
                             megaBayesABC!(Mi,wArray,mme.R.val,locus_effect_variances)
                         else
@@ -217,7 +214,6 @@ function MCMC_BayesianAlphabet(mme,df)
                     end
                 elseif Mi.method =="RR-BLUP"
                     if is_multi_trait && !is_nnbayes_partial
-                        # if is_mega_trait
                         if Mi.G.constraint==true
                             megaBayesC0!(Mi,wArray,mme.R.val)
                         else
@@ -230,7 +226,7 @@ function MCMC_BayesianAlphabet(mme,df)
                     end
                 elseif Mi.method == "BayesL"
                     if is_multi_trait && !is_nnbayes_partial
-                        # if is_mega_trait #problem with sampleGammaArray
+                        #problem with sampleGammaArray
                         if Mi.G.constraint==true
                             megaBayesL!(Mi,wArray,mme.R.val)
                         else
@@ -243,7 +239,6 @@ function MCMC_BayesianAlphabet(mme,df)
                     end
                 elseif Mi.method == "GBLUP"
                     if is_multi_trait && !is_nnbayes_partial
-                        # if is_mega_trait
                         if Mi.G.constraint==true
                             megaGBLUP!(Mi,wArray,mme.R.val,invweights)
                         else
@@ -260,7 +255,6 @@ function MCMC_BayesianAlphabet(mme,df)
                 ########################################################################
                 if Mi.estimatePi == true
                     if is_multi_trait && !is_nnbayes_partial
-                        # if is_mega_trait
                         if Mi.G.constraint==true
                             Mi.π = [samplePi(sum(Mi.δ[i]), Mi.nMarkers) for i in 1:mme.nModels]
                         else
@@ -358,7 +352,6 @@ function MCMC_BayesianAlphabet(mme,df)
             output_posterior_mean_variance(mme,nsamples)
             #mean and variance of posterior distribution
             if mme.pedTrmVec!=0
-                # polygenic_pos = findfirst(i -> i.randomType=="A", mme.rndTrmVec)
                 polygenic_effects_variance = inv(mme.rndTrmVec[polygenic_pos].Gi.val) 
             else
                 polygenic_effects_variance=false 

--- a/src/1.JWAS/src/MCMC/deprecated.jl
+++ b/src/1.JWAS/src/MCMC/deprecated.jl
@@ -1,7 +1,7 @@
 M   = mme.M[1].genotypes
 X   = M
 XPX = X'X
-lhs = XPX+I*mme.R[1,1]/mme.M[1].G[1,1]
+lhs = XPX+I*mme.R.val[1,1]/mme.M[1].G[1,1]
 Ch = cholesky(lhs)
 iL = inv(Ch.L)
 iLhs = inv(Ch)

--- a/src/1.JWAS/src/Nonlinear/nnbayes_check.jl
+++ b/src/1.JWAS/src/Nonlinear/nnbayes_check.jl
@@ -135,7 +135,6 @@ end
 # below function is to modify mme from multi-trait model to multiple single trait models
 # coded by Hao
 function nnbayes_mega_trait(mme)
-
     #mega_trait
     if mme.nModels == 1
         error("more than 1 trait is required for MegaLMM analysis.")
@@ -143,12 +142,12 @@ function nnbayes_mega_trait(mme)
     mme.MCMCinfo.constraint = true
 
     ##sample from scale-inv-⁠χ2, not InverseWishart
-    mme.df.residual  = mme.df.residual - mme.nModels
-    mme.scaleR       = diag(mme.scaleR/(mme.df.residual - 1))*(mme.df.residual-2)/mme.df.residual #diag(R_prior_mean)*(ν-2)/ν
+    mme.R.df    = mme.R.df - mme.nModels
+    mme.R.scale = diag(mme.R.scale/(mme.R.df - 1))*(mme.R.df-2)/mme.R.df #diag(R_prior_mean)*(ν-2)/ν
     if mme.M != 0
         for Mi in mme.M
-            Mi.df        = Mi.df - mme.nModels
-            Mi.scale    = diag(Mi.scale/(Mi.df - 1))*(Mi.df-2)/Mi.df
+            Mi.G.df    = Mi.G.df - mme.nModels
+            Mi.G.scale = diag(Mi.G.scale/(Mi.G.df - 1))*(Mi.G.df-2)/Mi.G.df
         end
     end
 
@@ -157,9 +156,9 @@ end
 # below function is to modify essential parameters for partial connected NN
 function nnbayes_partial_para_modify2(mme)
     for Mi in mme.M
-      Mi.scale = Mi.scale[1]
-      Mi.G = Mi.G[1,1]
-      Mi.genetic_variance=Mi.genetic_variance[1,1]
+      Mi.G.scale = Mi.G.scale[1]
+      Mi.G.val = Mi.G.val[1,1]
+      Mi.genetic_variance.val=Mi.genetic_variance.val[1,1]
     end
 end
 
@@ -205,4 +204,15 @@ function nnlmm_initialize_missing(mme,df)
     n_omics          = length(mme.lhsVec)             #number of omics
     full_omics       = n_observed_omics .== n_omics   #indicator for ind with full omics
     mme.incomplete_omics    = vec(.!full_omics)              #indicator for ind with no/partial omics
+end
+
+
+function nnmm_print_info_input_to_middle_layer(mme)
+        is_mega_trait = mme.R.constraint==true && mme.M[1].G.constraint==true #is_mega_trait when no residual and marker effect covariances 
+        if is_mega_trait
+            printstyled(" - Bayesian Alphabet:                multiple independent single-trait Bayesian models are used to sample marker effect. \n",bold=false,color=:green)
+            printstyled(" - Multi-threaded parallelism:       $nThread threads are used to run single-trait models in parallel. \n",bold=false,color=:green)
+        else
+            printstyled(" - Bayesian Alphabet:                multi-trait Bayesian models are used to sample marker effect. \n",bold=false,color=:green)
+        end
 end

--- a/src/1.JWAS/src/Nonlinear/nonlinear.jl
+++ b/src/1.JWAS/src/Nonlinear/nonlinear.jl
@@ -28,7 +28,7 @@ function sample_latent_traits(yobs,mme,ycorr,nonlinear_function)
     if mme.is_activation_fcn == true #Neural Network with activation function
         if sum(incomplete_omics) != 0   #at least 1 ind with incomplete omics
             #step 1. sample latent trait (only for individuals with incomplete omics data
-            ylats_new = hmc_one_iteration(10,0.1,ylats_old[incomplete_omics,:],yobs[incomplete_omics],mme.weights_NN,mme.R,σ2_yobs,ycorr2[incomplete_omics,:],nonlinear_function)
+            ylats_new = hmc_one_iteration(10,0.1,ylats_old[incomplete_omics,:],yobs[incomplete_omics],mme.weights_NN,mme.R.val,σ2_yobs,ycorr2[incomplete_omics,:],nonlinear_function)
             #step 2. update ylats with sampled latent traits
             ylats_old[incomplete_omics,:] = ylats_new
             #step 3. for individuals with partial omics data, put back the partial real omics.

--- a/src/1.JWAS/src/build_MME.jl
+++ b/src/1.JWAS/src/build_MME.jl
@@ -366,7 +366,7 @@ function getMME(mme::MME, df::DataFrame)
     #mixed model equations is obtained below for multi-trait PBLUP
     #with known residual covariance matrix and missing phenotypes.
       # if mme.MCMCinfo.mega_trait == true  #multiple single trait
-      if mme.R.constraint == true #tj: Hao, please confirm!!!
+      if mme.R.constraint == true #tj: Hao, please confirm! now we do not have mege_trait option. We only have constraint option for variances
         Ri = Diagonal(repeat(mme.invweights,mme.nModels))
       else  #multi-trait
         Ri = mkRi(mme,df,mme.invweights)

--- a/src/1.JWAS/src/build_MME.jl
+++ b/src/1.JWAS/src/build_MME.jl
@@ -38,9 +38,15 @@ R               = [6.72   24.84
 models          = build_model(model_equations,R);
 ```
 """
-function build_model(model_equations::AbstractString, R = false; df = 4.0,
+function build_model(model_equations::AbstractString, 
+                     ## residual variance: 
+                     R = false; df = 4.0, 
+                     estimate_variance=true, estimate_scale=false, 
+                     constraint=false, #for multi-trait only, constraint=true means no residual covariance among traits
+                     ## nnmm:
                      num_hidden_nodes = false, nonlinear_function = false, latent_traits=false, #nonlinear_function(x1,x2) = x1+x2
                      user_σ2_yobs = false, user_σ2_weightsNN = false,
+                     ## censored, categorical traits:
                      censored_trait = false, categorical_trait = false)
 
     if R != false && !isposdef(map(AbstractFloat,R))
@@ -107,10 +113,10 @@ function build_model(model_equations::AbstractString, R = false; df = 4.0,
             genotypei.ntraits = is_nnbayes_partial ? 1 : nModels
             genotypei.trait_names = is_nnbayes_partial ? trait_names : string.(lhsVec)
             if nModels != 1
-              genotypei.df = genotypei.df + nModels
+              genotypei.G.df = genotypei.G.df + nModels
             end
-            if !is_nnbayes_partial && (genotypei.G != false || genotypei.genetic_variance != false)
-              if size(genotypei.G,1) != nModels && size(genotypei.genetic_variance,1) != nModels
+            if !is_nnbayes_partial && (genotypei.G.val != false || genotypei.genetic_variance.val != false)
+              if size(genotypei.G.val,1) != nModels && size(genotypei.genetic_variance.val,1) != nModels
                 error("The genomic covariance matrix is not a ",nModels," by ",nModels," matrix.")
               end
             end
@@ -121,11 +127,27 @@ function build_model(model_equations::AbstractString, R = false; df = 4.0,
     end
 
   #create mme with genotypes
-  filter!(x->x.random_type != "genotypes",modelTerms)
-  filter!(x->x[2].random_type != "genotypes",dict)
-  mme = MME(nModels,modelVec,modelTerms,dict,lhsVec,R == false ? R : Float32.(R),Float32(df))
+  filter!(x->x.random_type != "genotypes",modelTerms) #remove "genotypes" from modelTerms
+  filter!(x->x[2].random_type != "genotypes",dict)    #remove "genotypes" from dict
+  
+
+  #set scale and df for residual variance
+  if nModels == 1
+    scale_R = R*(df - 2)/df
+    df_R    = df 
+  else
+    scale_R = R*(df - 1)
+    df_R    = df + nModels
+  end
+  
+  #initialize mme
+  mme = MME(nModels,modelVec,modelTerms,dict,lhsVec, 
+            Variance(R==false ? R : Float32.(R), #val
+                     Float32(df_R),              #df
+                     R==false ? R : scale_R,     #scale
+                     estimate_variance, estimate_scale, constraint))
   if length(genotypes) != 0
-    mme.M = genotypes
+    mme.M = genotypes #add genotypes into mme
   end
 
   #NNBayes:
@@ -343,7 +365,8 @@ function getMME(mme::MME, df::DataFrame)
     #such that no imputation of missing phenotypes is required.
     #mixed model equations is obtained below for multi-trait PBLUP
     #with known residual covariance matrix and missing phenotypes.
-      if mme.MCMCinfo.mega_trait == true  #multiple single trait
+      # if mme.MCMCinfo.mega_trait == true  #multiple single trait
+      if mme.R.constraint == true #tj: Hao, please confirm!!!
         Ri = Diagonal(repeat(mme.invweights,mme.nModels))
       else  #multi-trait
         Ri = mkRi(mme,df,mme.invweights)
@@ -354,13 +377,13 @@ function getMME(mme::MME, df::DataFrame)
 
     #Random effects parts in MME
     if mme.nModels == 1
-      #random_term.GiNew*mme.R - random_term.GiOld*mme.ROld
+      #random_term.GiNew*mme.R.val - random_term.GiOld*mme.ROld
       for random_term in mme.rndTrmVec #trick
-        random_term.GiOld = zero(random_term.GiOld)
+        random_term.GiOld.val = zero(random_term.GiOld.val)
       end
       addVinv(mme)
       for random_term in mme.rndTrmVec #trick
-        random_term.GiOld = copy(random_term.GiNew)
+        random_term.GiOld.val = copy(random_term.GiNew.val)
       end
     else
       addVinv(mme)

--- a/src/1.JWAS/src/categorical_and_censored_trait/categorical_and_censored_trait.jl
+++ b/src/1.JWAS/src/categorical_and_censored_trait/categorical_and_censored_trait.jl
@@ -33,7 +33,7 @@ function categorical_censored_traits_setup!(mme,df)
     ############################################################################
     nInd           = length(mme.obsID)
     nTrait         = mme.nModels
-    R              = mme.R
+    R              = mme.R.val
 
     starting_value = mme.sol
     cmean          = mme.X*starting_value[1:size(mme.mmeLhs,1)] #maker effects defaulting to all zeros
@@ -81,7 +81,7 @@ function categorical_censored_traits_setup!(mme,df)
             ##################################################################################
             for i in 1:nInd
                 if lower_bound[t][i] != upper_bound[t][i]
-                    ySparse[i,t] = rand(truncated(Normal(cmean[i,t], sqrt(R[t,t])), lower_bound[t][i], upper_bound[t][i])) #mme.R has been fixed to 1.0 for category single-trait analysis
+                    ySparse[i,t] = rand(truncated(Normal(cmean[i,t], sqrt(R[t,t])), lower_bound[t][i], upper_bound[t][i])) #mme.R.val has been fixed to 1.0 for category single-trait analysis
                 else
                     ySparse[i,t] = lower_bound[t][i] #mme.ySparse will also change since reshape is a reference, not copy
                 end
@@ -176,7 +176,7 @@ function sample_liabilities!(mme,ycorr,lower_bound,upper_bound)
     nInd           = length(mme.obsID)
     nTrait         = mme.nModels
     is_multi_trait = nTrait>1
-    R              = mme.R
+    R              = mme.R.val
     cmean          = reshape(cmean,      nInd,nTrait)
     ySparse        = reshape(mme.ySparse,nInd,nTrait) #mme.ySparse will also be updated since reshape is a reference, not copy
     ycorr_ref      = reshape(ycorr,      nInd,nTrait) #ycorr will be updated since reshape is a reference, not copy

--- a/src/1.JWAS/src/input_data_validation.jl
+++ b/src/1.JWAS/src/input_data_validation.jl
@@ -481,20 +481,4 @@ function G_constraint!(mme)
 end
 
 
-#multi-trait constraint on non-genetic random effects: modify df and scale
-function A_constraint!(mme)
-    if mme > 0
-        for Mi in mme.M
-            #print
-            geno_name = Mi.name
-            printstyled("Constraint on marker effect variance matrix (i.e., zero covariance) for $geno_name \n",bold=false,color=:green)
-            #check
-            if mme.nModels == 1 && Mi.G.constraint==true
-                error("constraint==true is for multi-trait only")
-            end
-            #modify df and scale
-            Mi.G.df    = Mi.G.df - mme.nModels
-            Mi.G.scale = Diagonal(Mi.G.scale/(Mi.G.df - 1))*(Mi.G.df-2)/Mi.G.df #a diagonal matrix
-        end
-    end
-end
+#TO-DO: multi-trait constraint on non-genetic random effects: modify df and scale

--- a/src/1.JWAS/src/input_data_validation.jl
+++ b/src/1.JWAS/src/input_data_validation.jl
@@ -35,7 +35,7 @@ function errors_args(mme)
                 println("BayesA is equivalent to BayesB with known π=0. BayesB with known π=0 runs.")
             end
             if Mi.method == "GBLUP"
-                if Mi.genetic_variance == false && Mi.G != false
+                if Mi.genetic_variance.val == false && Mi.G.val != false
                     error("Please provide values for the genetic variance for GBLUP analysis")
                 end
                 if mme.MCMCinfo.single_step_analysis == true
@@ -241,47 +241,47 @@ function set_default_priors_for_variance_components(mme,df)
   #genetic variance or marker effect variance
   if mme.M!=0
     for Mi in mme.M
-      if Mi.G == false && Mi.genetic_variance == false
+      if Mi.G.val == false && Mi.genetic_variance.val == false
           printstyled("Prior information for genomic variance is not provided and is generated from the data.\n",bold=false,color=:green)
           if mme.nModels==1 && mme.MCMCinfo.RRM == false
-              Mi.genetic_variance = varg[1,1]
+              Mi.genetic_variance.val = varg[1,1]
           elseif mme.nModels==1 && mme.MCMCinfo.RRM != false
-              Mi.genetic_variance = diagm(0=>fill(varg[1,1],size(mme.MCMCinfo.RRM,2)))
+              Mi.genetic_variance.val = diagm(0=>fill(varg[1,1],size(mme.MCMCinfo.RRM,2)))
           elseif mme.nModels>1
-              Mi.genetic_variance = varg
-          end #mme.M.G and its scale parameter will be reset in function set_marker_hyperparameters_variances_and_pi
+              Mi.genetic_variance.val = varg
+          end #mme.M.G.val and its scale parameter will be reset in function set_marker_hyperparameters_variances_and_pi
       end
     end
   end
   #residual effects
-  if mme.nModels==1 && isposdef(mme.R) == false #single-trait
+  if mme.nModels==1 && isposdef(mme.R.val) == false #single-trait
     printstyled("Prior information for residual variance is not provided and is generated from the data.\n",bold=false,color=:green)
     is_categorical_or_binary_trait = mme.traits_type==["categorical"] || mme.traits_type==["categorical(binary)"]
-    mme.R = mme.ROld = is_categorical_or_binary_trait ? 1.0 : vare[1,1]  #residual variance known to be 1.0 in single trait categorical analysis
-    mme.scaleR = mme.R*(mme.df.residual-2)/mme.df.residual
-  elseif mme.nModels>1 && isposdef(mme.R) == false #multi-trait
+    mme.R.val = mme.ROld = is_categorical_or_binary_trait ? 1.0 : vare[1,1]  #residual variance known to be 1.0 in single trait categorical analysis
+    mme.R.scale = mme.R.val*(mme.R.df-2)/mme.R.df
+  elseif mme.nModels>1 && isposdef(mme.R.val) == false #multi-trait
     printstyled("Prior information for residual variance is not provided and is generated from the data.\n",bold=false,color=:green)
-    mme.R = mme.ROld = vare
-    mme.scaleR = mme.R*(mme.df.residual - mme.nModels - 1)
+    mme.R.val = mme.ROld = vare
+    mme.R.scale = mme.R.val*(mme.R.df - mme.nModels - 1)
   end
   #random effects
   if length(mme.rndTrmVec) != 0
     for randomEffect in mme.rndTrmVec
-      if isposdef(randomEffect.Gi) == false
+      if isposdef(randomEffect.Gi.val) == false
         printstyled("Prior information for random effect variance is not provided and is generated from the data.\n",bold=false,color=:green)
-        myvarout  = [split(i,":")[1] for i in randomEffect.term_array]
-        myvarin   = string.(mme.lhsVec)
-        Zdesign   = mkmat_incidence_factor(myvarout,myvarin)
+        myvarout  = [split(i,":")[1] for i in randomEffect.term_array] #e.g., ["y1:x2","y2:x2"] -> ["y1","y2"]
+        myvarin   = string.(mme.lhsVec) #e.g., ["y1","y2","y3"]
+        Zdesign   = mkmat_incidence_factor(myvarout,myvarin) #design matrix (sparse)
         if randomEffect.randomType == "A"
             G = diagm(Zdesign*diag(varg))
         else
             G = diagm(Zdesign*diag(vare))
         end
-        randomEffect.Gi = randomEffect.GiOld = randomEffect.GiNew = Symmetric(inv(G))
-        randomEffect.scale = G*(randomEffect.df-length(randomEffect.term_array)-1)
+        randomEffect.Gi.val = randomEffect.GiOld.val = randomEffect.GiNew.val = Symmetric(inv(G))
+        randomEffect.Gi.scale = randomEffect.GiOld.scale = randomEffect.GiNew.scale = G*(randomEffect.Gi.df-length(randomEffect.term_array)-1)
         if randomEffect.randomType == "A"
-          mme.Gi = randomEffect.Gi
-          mme.scalePed = randomEffect.scale
+          mme.Gi = randomEffect.Gi.val
+          mme.scalePed = randomEffect.Gi.scale
         end
       end
     end
@@ -444,6 +444,57 @@ function init_mixed_model_equations(mme,df,starting_value)
                 Mi.α = map((mme.MCMCinfo.double_precision ? Float64 : Float32),Mi.α)
             end
             Mi.α = [Mi.α[(traiti-1)*nsol+1:traiti*nsol] for traiti = 1:Mi.ntraits]
+        end
+    end
+end
+
+
+#multi-trait constraint on R: modify df and scale for residual variance
+function R_constraint!(mme)
+    #print
+    printstyled("Constraint on residual variance matrix (i.e., zero covariance)\n",bold=false,color=:green)
+    #check
+    if mme.nModels == 1 && mme.R.constraint==true
+        error("constraint==true is for multi-trait only")
+    end
+    #modify df and scale
+    mme.R.df    = mme.R.df - mme.nModels
+    mme.R.scale = Diagonal(mme.R.scale/(mme.R.df - 1))*(mme.R.df-2)/mme.R.df #Diagonal(R_prior_mean)*(ν-2)/ν, a diagonal matrix
+end
+
+#multi-trait constraint on G: modify df and scale for marker effect variance
+function G_constraint!(mme)
+    if length(mme.M) > 0
+        for Mi in mme.M
+            #print
+            geno_name = Mi.name
+            printstyled("Constraint on marker effect variance matrix (i.e., zero covariance) for $geno_name \n",bold=false,color=:green)
+            #check
+            if mme.nModels == 1 && Mi.G.constraint==true
+                error("constraint==true is for multi-trait only")
+            end
+            #modify df and scale
+            Mi.G.df    = Mi.G.df - mme.nModels
+            Mi.G.scale = Diagonal(Mi.G.scale/(Mi.G.df - 1))*(Mi.G.df-2)/Mi.G.df #a diagonal matrix
+        end
+    end
+end
+
+
+#multi-trait constraint on non-genetic random effects: modify df and scale
+function A_constraint!(mme)
+    if mme > 0
+        for Mi in mme.M
+            #print
+            geno_name = Mi.name
+            printstyled("Constraint on marker effect variance matrix (i.e., zero covariance) for $geno_name \n",bold=false,color=:green)
+            #check
+            if mme.nModels == 1 && Mi.G.constraint==true
+                error("constraint==true is for multi-trait only")
+            end
+            #modify df and scale
+            Mi.G.df    = Mi.G.df - mme.nModels
+            Mi.G.scale = Diagonal(Mi.G.scale/(Mi.G.df - 1))*(Mi.G.df-2)/Mi.G.df #a diagonal matrix
         end
     end
 end

--- a/src/1.JWAS/src/input_data_validation.jl
+++ b/src/1.JWAS/src/input_data_validation.jl
@@ -452,7 +452,7 @@ end
 #multi-trait constraint on R: modify df and scale for residual variance
 function R_constraint!(mme)
     #print
-    printstyled("Constraint on residual variance matrix (i.e., zero covariance)\n",bold=false,color=:green)
+    printstyled("Constraint on residual variance-covariance matrix (i.e., zero covariance)\n",bold=false,color=:green)
     #check
     if mme.nModels == 1 && mme.R.constraint==true
         error("constraint==true is for multi-trait only")
@@ -468,7 +468,7 @@ function G_constraint!(mme)
         for Mi in mme.M
             #print
             geno_name = Mi.name
-            printstyled("Constraint on marker effect variance matrix (i.e., zero covariance) for $geno_name \n",bold=false,color=:green)
+            printstyled("Constraint on marker effect variance-covariance matrix (i.e., zero covariance) for $geno_name \n",bold=false,color=:green)
             #check
             if mme.nModels == 1 && Mi.G.constraint==true
                 error("constraint==true is for multi-trait only")

--- a/src/1.JWAS/src/iterative_solver/solver.jl
+++ b/src/1.JWAS/src/iterative_solver/solver.jl
@@ -40,7 +40,7 @@ function solve(mme::MME,
         return [getNames(mme) Gibbs(A,x,b,
                               maxiter,printout_frequency=printout_frequency)]
     elseif solver=="Gibbs" && mme.nModels==1
-        return [getNames(mme) Gibbs(A,x,b,mme.R,
+        return [getNames(mme) Gibbs(A,x,b,mme.R.val,
                               maxiter,printout_frequency=printout_frequency)]
     elseif solver=="default"
         println("To solve the equations, please choose a solver. (run ?solve for help)")

--- a/src/1.JWAS/src/markers/BayesianAlphabet/GBLUP.jl
+++ b/src/1.JWAS/src/markers/BayesianAlphabet/GBLUP.jl
@@ -32,12 +32,12 @@ end
 
 function megaGBLUP!(Mi::Genotypes,wArray,vare,Rinv)
     Threads.@threads for i in 1:length(wArray) #ntraits
-        GBLUP!(Mi.genotypes,Mi.α[i],Mi.D,wArray[i],vare[i,i],Mi.G[i,i],Rinv,Mi.nObs)
+        GBLUP!(Mi.genotypes,Mi.α[i],Mi.D,wArray[i],vare[i,i],Mi.G.val[i,i],Rinv,Mi.nObs)
     end
 end
 
 function GBLUP!(Mi::Genotypes,ycorr,vare,Rinv) #single-trait
-    GBLUP!(Mi.genotypes,Mi.α[1],Mi.D,ycorr,vare,Mi.G[1,1],Rinv,Mi.nObs)
+    GBLUP!(Mi.genotypes,Mi.α[1],Mi.D,ycorr,vare,Mi.G.val[1,1],Rinv,Mi.nObs)
 end
 
 function GBLUP!(genotypes,α,D,ycorr,vare,vara,Rinv,nObs)
@@ -51,7 +51,7 @@ end
 
 function MTGBLUP!(Mi::Genotypes,ycorr_array,ycorr,vare,Rinv)
     iR0      = inv(vare)
-    iGM      = inv(Mi.G)
+    iGM      = inv(Mi.G.val)
     for trait = 1:Mi.ntraits
         ycorr_array[trait][:] = ycorr_array[trait] + Mi.genotypes*Mi.α[trait]
     end

--- a/src/1.JWAS/src/markers/BayesianAlphabet/MTBayesABC.jl
+++ b/src/1.JWAS/src/markers/BayesianAlphabet/MTBayesABC.jl
@@ -97,14 +97,14 @@ function MTBayesABC_samplerII!(xArray,
                     betaArray,
                     deltaArray,
                     alphaArray,
-                    vare, #mme.R, t-by-t
+                    vare, #mme.R.val, t-by-t
                     varEffects, # vector of length #SNPs, each element is a t-by-t covariance matrix
                     BigPi) #genotypes.π
 
     nMarkers = length(xArray)
     ntraits  = length(alphaArray)
 
-    Rinv     = inv(vare) #inv(mme.R)
+    Rinv     = inv(vare) #inv(mme.R.val)
     Ginv     = inv.(varEffects)
 
     β        = zeros(typeof(betaArray[1][1]),ntraits)

--- a/src/1.JWAS/src/markers/tools4genotypes.jl
+++ b/src/1.JWAS/src/markers/tools4genotypes.jl
@@ -153,44 +153,44 @@ function set_marker_hyperparameters_variances_and_pi(mme::MME)
                 Mi.π = Pi
             end
             #(2) marker effect variances
-            if Mi.G == false
+            if Mi.G.val == false
                 if Mi.method!="GBLUP"
                     genetic2marker(Mi,Mi.π)
                     println()
                     if mme.nModels != 1 || mme.MCMCinfo.RRM != false
-                      if !isposdef(Mi.G) #also work for scalar
+                      if !isposdef(Mi.G.val) #also work for scalar
                         error("Marker effects covariance matrix is not postive definite! Please modify the argument: Pi.")
                       end
                       println("The prior for marker effects covariance matrix is calculated from genetic covariance matrix and Π.")
                       println("The mean of the prior for the marker effects covariance matrix is:")
                       if mme.MCMCinfo.printout_model_info==true
-                          Base.print_matrix(stdout,round.(Mi.G,digits=6))
+                          Base.print_matrix(stdout,round.(Mi.G.val,digits=6))
                       end
                     else
-                      if !isposdef(Mi.G) #positive scalar (>0)
+                      if !isposdef(Mi.G.val) #positive scalar (>0)
                         error("Marker effects variance is negative!")
                       end
                       println("The prior for marker effects variance is calculated from the genetic variance and π.")
                       print("The mean of the prior for the marker effects variance is: ")
-                      print(round.(Mi.G,digits=6))
+                      print(round.(Mi.G.val,digits=6))
                     end
                     print("\n\n\n")
                 elseif Mi.method == "GBLUP"
-                    Mi.G  = Mi.genetic_variance
+                    Mi.G.val  = Mi.genetic_variance.val
                 end
             end
             #(3) scale parameter for marker effect variance
             if Mi.ntraits == 1 && mme.MCMCinfo.RRM == false
-                Mi.scale = Mi.G*(Mi.df-Mi.ntraits-1)/Mi.df
+                Mi.G.scale = Mi.G.val*(Mi.G.df-Mi.ntraits-1)/Mi.G.df
             else
-                Mi.scale = Mi.G*(Mi.df-Mi.ntraits-1)
+                Mi.G.scale = Mi.G.val*(Mi.G.df-Mi.ntraits-1)
             end
         end
     end
 end
 
 function genetic2marker(M::Genotypes,Pi::Dict)
-  ntraits = size(M.genetic_variance,1)
+  ntraits = size(M.genetic_variance.val,1)
   denom   = zeros(ntraits,ntraits)
   for i in 1:ntraits
     for j in i:ntraits
@@ -200,9 +200,9 @@ function genetic2marker(M::Genotypes,Pi::Dict)
       denom[j,i] = denom[i,j]
     end
   end
-  M.G = M.genetic_variance ./ denom
+  M.G.val = M.genetic_variance.val ./ denom
 end
 
 function genetic2marker(M::Genotypes,π::Float64)
-    M.G = M.genetic_variance/((1-π)*M.sum2pq)
+    M.G.val = M.genetic_variance.val/((1-π)*M.sum2pq)
 end

--- a/src/1.JWAS/src/output.jl
+++ b/src/1.JWAS/src/output.jl
@@ -396,11 +396,8 @@ function output_MCMC_samples_setup(mme,nIter,output_samples_frequency,file_name=
           writedlm(outfile["EBV_"*string(mme.lhsVec[traiti])],transubstrarr(mme.output_ID),',')
       end
       if mme.MCMCinfo.output_heritability == true && mme.MCMCinfo.single_step_analysis == false
-          if mme.M[1].G.constraint == false  #may need change when there are multiple M
-              varheader = repeat(mytraits,inner=length(mytraits)).*"_".*repeat(mytraits,outer=length(mytraits))
-          else
-              varheader = transubstrarr(map(string,mme.lhsVec))
-          end
+          varheader = repeat(mytraits,inner=length(mytraits)).*"_".*repeat(mytraits,outer=length(mytraits))
+
           writedlm(outfile["genetic_variance"],transubstrarr(varheader),',')
           if mme.MCMCinfo.RRM == false
               writedlm(outfile["heritability"],transubstrarr(map(string,mme.lhsVec)),',')
@@ -446,7 +443,7 @@ function output_MCMC_samples(mme,vRes,G0,
             writedlm(outfile["marker_effects_"*Mi.name*"_"*geno_names[traiti]],Mi.α[traiti]',',')
          end
           
-         if Mi.G.val != false && Mi.G.constraint == false #Do not save marker effect variances with constraint
+         if Mi.G.val != false && mme.nonlinear_function == false #do not save marker effect variances in NNMM to save space
               if mme.nModels == 1
                   writedlm(outfile["marker_effects_variances"*"_"*Mi.name],Mi.G.val',',')
               else

--- a/src/1.JWAS/src/random_effects.jl
+++ b/src/1.JWAS/src/random_effects.jl
@@ -104,8 +104,10 @@ function set_random(mme::MME,randomStr::AbstractString,G=false;Vinv=0,names=[],d
     end
     names   = string.(names)
     df      = Float32(df)
-    #check for constraint
-    #?now
+    
+    if constraint != false #check constraint
+      error("Constraint for set_random is not supported now.")
+    end
 
     ############################################################################
     #add trait names (model equation number) to variables;
@@ -129,8 +131,6 @@ function set_random(mme::MME,randomStr::AbstractString,G=false;Vinv=0,names=[],d
         error(trm," is not found in model equation.")
       end
     end                                               # "y1:litter"; "y2:litter"; "y1:group"
-    # 
-    # e.g. set model.modelTerms[4].random_type
     ############################################################################
     #Set type of model terms
     ############################################################################
@@ -154,7 +154,7 @@ function set_random(mme::MME,randomStr::AbstractString,G=false;Vinv=0,names=[],d
     end
     #Gi            : multi-trait;
     #GiOld & GiNew : single-trait, allow multiple correlated effects in single-trait
-    Gi = GiOld = GiNew = (G == false ? false : Symmetric(inv(Float32.(G)))) #not reference
+    Gi = GiOld = GiNew = (G == false ? false : Symmetric(inv(Float32.(G))))
     ############################################################################
     #return random_effct type
     ############################################################################

--- a/src/1.JWAS/src/residual.jl
+++ b/src/1.JWAS/src/residual.jl
@@ -13,7 +13,7 @@ end
 #make tricky Ri (big) allowing NA in phenotypes and fixed effects
 #make ResVar, dictionary for Rinv, no sample Missing residuals
 function mkRi(mme::MME,df::DataFrame,Rinv)
-    resVar   = ResVar(mme.R,Dict())
+    resVar   = ResVar(mme.R.val,Dict())
     tstMsng  = .!ismissing.(Matrix(df[!,mme.lhsVec]))
     if mme.missingPattern == false
         mme.missingPattern = tstMsng
@@ -62,9 +62,9 @@ function sampleMissingResiduals(mme,resVec)
                 mybool = mybool .& (msngPtrn[:,i].==notmissing[i])
             end
             #create cov and var matrices for BLP imputation
-            Ri  = inv(Symmetric(mme.R[notmissing,notmissing]))
-            Rc  = mme.R[.!notmissing,notmissing]
-            L   = (cholesky(Symmetric(mme.R[.!notmissing,.!notmissing] - Rc*Ri*Rc')).U)#scalar cholesky
+            Ri  = inv(Symmetric(mme.R.val[notmissing,notmissing]))
+            Rc  = mme.R.val[.!notmissing,notmissing]
+            L   = (cholesky(Symmetric(mme.R.val[.!notmissing,.!notmissing] - Rc*Ri*Rc')).U)#scalar cholesky
             #imputation
             mydata[mybool,.!notmissing]= mydata[mybool,notmissing]*Ri*Rc' + randn(sum(mybool),sum(.!notmissing))*L
         end
@@ -84,8 +84,8 @@ end
 #             msng    = .!notMsng
 #             resi    = resVec[yIndex .+ i][notMsng]
 #             Ri      = mme.resVar.RiDict[notMsng][notMsng,notMsng]
-#             Rc      = mme.R[msng,notMsng]
-#             L       = (cholesky(Symmetric(mme.R[msng,msng] - Rc*Ri*Rc')).U)'
+#             Rc      = mme.R.val[msng,notMsng]
+#             L       = (cholesky(Symmetric(mme.R.val[msng,msng] - Rc*Ri*Rc')).U)'
 #             resVec[(yIndex .+ i)[msng]] = Rc*Ri*resi + L*randn(sum(msng))
 #             #resVec[yIndex+i][msng] = Rc*Ri*resi + L*randn(nMsng) this does not work!
 #         end

--- a/src/1.JWAS/src/types.jl
+++ b/src/1.JWAS/src/types.jl
@@ -73,7 +73,7 @@ end
 #or missing phenotypes are not imputed at each step of MCMC (no marker effects).
 ################################################################################
 mutable struct ResVar
-    R0::Union{Array{Float64,2},Array{Float32,2}} #2-by-2 co
+    R0::Union{Array{Float64,2},Array{Float32,2}}
     RiDict::Dict{BitArray{1},Union{Array{Float64,2},Array{Float32,2}}}
 end
 
@@ -85,9 +85,9 @@ end
 ################################################################################
 mutable struct RandomEffect   #Better to be a dict? key: term_array::Array{AbstractString,1}??
     term_array::Array{AbstractString,1}
-    Gi     #covariance matrix (multi-trait) #::Array{Float64,2}-> Variance struct
-    GiOld  #specific for lambda version of MME (single-trait) #::Array{Float64,2}
-    GiNew  #specific for lambda version of MME (single-trait) #::Array{Float64,2}
+    Gi     #covariance matrix (multi-trait) #the "Variance" object
+    GiOld  #specific for lambda version of MME (single-trait) #Variance.val has type ::Array{Float64,2}
+    GiNew  #specific for lambda version of MME (single-trait) #Variance.val has type ::Array{Float64,2}
     # df::AbstractFloat
     # scale #::Array{Float64,2}
     Vinv # 0, identity matrix
@@ -111,7 +111,7 @@ mutable struct Genotypes
   ntraits           #number of traits included in the model
 
   genetic_variance  #genetic variance, type: Variance struct
-  G       #marker effect variance; ST->Float64;MT->Array{Float64,2}, type: Variance struct
+  G       #marker effect variance; the "Variance" object, for Variance.val: ST->Float64;MT->Array{Float64,2}
 #   scale             #scale parameter for marker effect variance (G)
 #   df                #degree of freedom
 
@@ -277,7 +277,6 @@ mutable struct MME
     thresholds    #thresholds for categorial&binary traits. Dictionary: 1=>[-Inf,0,Inf], where 1 means the 1st trait
 
     function MME(nModels,modelVec,modelTerms,dict,lhsVec,R) #MME(nModels,modelVec,modelTerms,dict,lhsVec,R,ν)
-
         return new(nModels,modelVec,modelTerms,dict,lhsVec,[],
                    0,0,[],0,0,
                    0,0,zeros(1,1),zeros(1,1),zeros(1,1),zeros(1,1),false,false,

--- a/src/1.JWAS/src/variance_components.jl
+++ b/src/1.JWAS/src/variance_components.jl
@@ -92,7 +92,7 @@ function sample_variance(ycorr_array, nobs, df, scale, invweights, constraint; b
     else  #diagonal elements only, from scale-inv-⁠χ2
         R  = Diagonal(zeros(ntraits))
         for traiti = 1:ntraits
-            R[traiti,traiti]= (SSE[traiti,traiti]+scale[traiti,traiti])/rand(Chisq(nobs+df)) #scale is a vector in mega_trait, where t-th entry is the scale for t-th trait
+            R[traiti,traiti]= (SSE[traiti,traiti]+df*scale[traiti,traiti])/rand(Chisq(nobs+df)) 
         end
     end
     return R
@@ -105,7 +105,6 @@ function sampleVCs(mme::MME,sol::Union{Array{Float64,1},Array{Float32,1}})
       myI        = SparseMatrixCSC{mme.MCMCinfo.double_precision ? Float64 : Float32}(I, mme.modelTermDict[term_array[1]].nLevels, mme.modelTermDict[term_array[1]].nLevels)
       Vi         = (random_term.Vinv!=0) ? random_term.Vinv : myI
       S          = zeros(length(term_array),length(term_array))
-      @show size(S)
       for i = 1:length(term_array)
           termi      = term_array[i]
           randTrmi   = mme.modelTermDict[termi]
@@ -113,7 +112,6 @@ function sampleVCs(mme::MME,sol::Union{Array{Float64,1},Array{Float32,1}})
           endPosi    = startPosi + randTrmi.nLevels - 1
           for j = i:length(term_array)
               termj     = term_array[j]
-              @show termi,termj
               randTrmj  = mme.modelTermDict[termj]
               startPosj = randTrmj.startPos
               endPosj   = startPosj + randTrmj.nLevels - 1

--- a/src/1.JWAS/src/variance_components.jl
+++ b/src/1.JWAS/src/variance_components.jl
@@ -90,9 +90,9 @@ function sample_variance(ycorr_array, nobs, df, scale, invweights, constraint; b
             R  = sample_from_conditional_inverse_Wishart(df + nobs, convert(Array,Symmetric(inv(scale + SSE))), binary_trait_index)
         end
     else  #diagonal elements only, from scale-inv-⁠χ2
-        R  = zeros(ntraits,ntraits)
+        R  = Diagonal(zeros(ntraits))
         for traiti = 1:ntraits
-            R[traiti,traiti]= (SSE[traiti,traiti]+scale[traiti])/rand(Chisq(nobs+df)) #scale is a vector in mega_trait, where t-th entry is the scale for t-th trait
+            R[traiti,traiti]= (SSE[traiti,traiti]+scale[traiti,traiti])/rand(Chisq(nobs+df)) #scale is a vector in mega_trait, where t-th entry is the scale for t-th trait
         end
     end
     return R
@@ -105,6 +105,7 @@ function sampleVCs(mme::MME,sol::Union{Array{Float64,1},Array{Float32,1}})
       myI        = SparseMatrixCSC{mme.MCMCinfo.double_precision ? Float64 : Float32}(I, mme.modelTermDict[term_array[1]].nLevels, mme.modelTermDict[term_array[1]].nLevels)
       Vi         = (random_term.Vinv!=0) ? random_term.Vinv : myI
       S          = zeros(length(term_array),length(term_array))
+      @show size(S)
       for i = 1:length(term_array)
           termi      = term_array[i]
           randTrmi   = mme.modelTermDict[termi]
@@ -112,6 +113,7 @@ function sampleVCs(mme::MME,sol::Union{Array{Float64,1},Array{Float32,1}})
           endPosi    = startPosi + randTrmi.nLevels - 1
           for j = i:length(term_array)
               termj     = term_array[j]
+              @show termi,termj
               randTrmj  = mme.modelTermDict[termj]
               startPosj = randTrmj.startPos
               endPosj   = startPosj + randTrmj.nLevels - 1
@@ -120,13 +122,13 @@ function sampleVCs(mme::MME,sol::Union{Array{Float64,1},Array{Float32,1}})
           end
       end
        q  = mme.modelTermDict[term_array[1]].nLevels
-       G0 = rand(InverseWishart(random_term.df + q, convert(Array,Symmetric(random_term.scale + S))))
+       G0 = rand(InverseWishart(random_term.Gi.df + q, convert(Array,Symmetric(random_term.Gi.scale + S))))
        if mme.MCMCinfo.double_precision == false
            G0 = Float32.(G0)
        end
-       random_term.GiOld = copy(random_term.GiNew)
-       random_term.GiNew = copy(inv(G0))
-       random_term.Gi    = copy(inv(G0))
+       random_term.GiOld.val = copy(random_term.GiNew.val)
+       random_term.GiNew.val = copy(inv(G0))
+       random_term.Gi.val    = copy(inv(G0))
        if random_term.randomType == "A"
            mme.Gi    = random_term.Gi
        end
@@ -135,7 +137,7 @@ end
 ########################################################################
 # Marker Effects Variance
 ########################################################################
-function sample_marker_effect_variance(Mi,constraint=false)
+function sample_marker_effect_variance(Mi)
     if Mi.method == "BayesL"
         invweights = 1 ./ Mi.gammaArray
     elseif Mi.method == "GBLUP"
@@ -146,27 +148,27 @@ function sample_marker_effect_variance(Mi,constraint=false)
     if Mi.ntraits == 1
         if Mi.method in ["BayesC","BayesL","RR-BLUP","GBLUP"]
             nloci = Mi.method == "BayesC" ? sum(Mi.δ[1]) : Mi.nMarkers
-            Mi.G  = sample_variance(Mi.α[1], nloci, Mi.df, Mi.scale, invweights)
+            Mi.G.val  = sample_variance(Mi.α[1], nloci, Mi.G.df, Mi.G.scale, invweights)
             if Mi.method == "BayesL"
-                sampleGammaArray!(Mi.gammaArray,Mi.α,Mi.G) # MH sampler of gammaArray (Appendix C in paper)
+                sampleGammaArray!(Mi.gammaArray,Mi.α,Mi.G.val) # MH sampler of gammaArray (Appendix C in paper)
             end
         elseif Mi.method == "BayesB"
             for j=1:Mi.nMarkers
-                Mi.G[j] = sample_variance(Mi.β[1][j],1,Mi.df, Mi.scale)
+                Mi.G.val[j] = sample_variance(Mi.β[1][j],1,Mi.G.df, Mi.G.scale)
             end
         end
     else
         if Mi.method in ["RR-BLUP","BayesC","BayesL","GBLUP"]
             data = (Mi.method == "BayesC" ? Mi.β : Mi.α)
-            Mi.G =sample_variance(data, Mi.nMarkers, Mi.df, Mi.scale, invweights, constraint)
+            Mi.G.val =sample_variance(data, Mi.nMarkers, Mi.G.df, Mi.G.scale, invweights, Mi.G.constraint)
             if Mi.method == "BayesL"
-                sampleGammaArray!(Mi.gammaArray,Mi.α,Mi.G) #MH sampler of gammaArray (Appendix C in paper)
+                sampleGammaArray!(Mi.gammaArray,Mi.α,Mi.G.val) #MH sampler of gammaArray (Appendix C in paper)
             end
         elseif Mi.method == "BayesB" #potential slowdown (scalar multiplication is used instead of matrices)
             marker_effects_matrix = reduce(hcat,Mi.β)'
             for i = 1:Mi.nMarkers
                 data    = marker_effects_matrix[:,i]
-                Mi.G[i] = sample_variance(data, 1, Mi.df, Mi.scale, false, constraint)
+                Mi.G.val[i] = sample_variance(data, 1, Mi.G.df, Mi.G.scale, false, Mi.G.constraint)
             end
         end
     end

--- a/src/1.JWAS/src/variance_components.jl
+++ b/src/1.JWAS/src/variance_components.jl
@@ -92,7 +92,7 @@ function sample_variance(ycorr_array, nobs, df, scale, invweights, constraint; b
     else  #diagonal elements only, from scale-inv-⁠χ2
         R  = zeros(ntraits,ntraits)
         for traiti = 1:ntraits
-            R[traiti,traiti]= (SSE[traiti,traiti]+df*scale[traiti])/rand(Chisq(nobs+df))
+            R[traiti,traiti]= (SSE[traiti,traiti]+scale[traiti])/rand(Chisq(nobs+df)) #scale is a vector in mega_trait, where t-th entry is the scale for t-th trait
         end
     end
     return R

--- a/src/3.GWAS/src/GWAS.jl
+++ b/src/3.GWAS/src/GWAS.jl
@@ -174,7 +174,7 @@ function GWAS(mme,map_file,marker_effects_file::AbstractString...;
             end
             winVarProps[isnan.(winVarProps)] .= 0.0 #replace NaN caused by situations no markers are included in the model
             WPPA, prop_genvar = vec(mean(winVarProps .> threshold,dims=1)), vec(mean(winVarProps,dims=1))
-            prop_genvar = round.(prop_genvar*100,digits=2)
+            prop_genvar = prop_genvar*100
             winVarmean = vec(mean(winVar,dims=1))
             winVarstd  = vec(std(winVar,dims=1))
 


### PR DESCRIPTION
wiki page: https://github.com/reworkhow/JWAS.jl/wiki/Constraint-on-variance-components
1. change `estimateScale` to `estimate_scale`;
2. delete `mega_trait` because it equals adding constraint on variances
3. move `constraint` argument in `runMCMC()` to `build_model()`. This is to put all residual variance related argument together.
4. add variance structural, and modify related code. add printed info if constraint; add error if constraint in ST
      ```
      mutable struct Variance
          val::Union{AbstractFloat, AbstractArray, Bool}   #value of the variance, e.g., single-trait: 1.5, two-trait: [1.3 0.4; 0.4 0.8]
          df::Union{AbstractFloat,Bool}                    #degrees of freedom, e.g., 4.0
          scale::Union{AbstractFloat, AbstractArray, Bool} #scale, e.g., single-trait: 1.0, two-trait: [1.0 0; 0 1.0]
      
          estimate_variance::Bool  #estimate_variance=true means estimate variance at each MCMC iteration
          estimate_scale::Bool     #estimate_scale=true means estimate scale at each MCMC iteration
          constraint::Bool        #constraint=true means in multi-trait analysis, covariance is zero
      end
      ```
5. make scale in MT be a diagonal matrix everywhere
6. organize arguments in `build_model()`, `get_genotypes()`, `set_random ()`
7. relocate some comments in NNMM
8. relocate initialization of scale_R, df_R to `build_model()`
9. add `R_constraint!()` and `G_constraint!()` functions to change scale and df if constraint