### PR TITLE
set the starting value of ROld as scalar, not a `Variance` object

### DIFF
--- a/src/1.JWAS/src/types.jl
+++ b/src/1.JWAS/src/types.jl
@@ -281,7 +281,7 @@ mutable struct MME
                    0,0,[],0,0,
                    0,0,zeros(1,1),zeros(1,1),zeros(1,1),zeros(1,1),false,false,
                    [],
-                   R,0,0,R,false,false, #R,0,0,R,scaleR,false,false,
+                   R,0,0,R.val,false,false, #starting value of mme.ROld is a scalar equal to mme.R.val
                    [],
                    0,
                    1,


### PR DESCRIPTION
Old: starting value of mme.ROld is set to mme.R, which is a Variance object. This caused an error in calculation.
Now: starting value of mme.ROld is set to mme.R.val, which is a scalar used in subsequent calculations.
