### PR TITLE
improve get_genotypes() function before line "isGRM = false"

### DIFF
--- a/src/1.JWAS/src/markers/readgenotypes.jl
+++ b/src/1.JWAS/src/markers/readgenotypes.jl
@@ -1,4 +1,6 @@
 """
+DEPRECATED!! Please use get_genotypes()
+
     add_genotypes(mme::MME,M::Union{AbstractString,Array{Float64,2},Array{Float32,2},Array{Any,2},DataFrames.DataFrame},G=false;
                   header=false,rowID=false,separator=',',
                   center=true,G_is_marker_variance=false,df=4)
@@ -51,11 +53,19 @@ end
 #1)load genotypes from a text file (1st column: individual IDs; 1st row: marker IDs (optional))
 #2)load genotypes from Array or DataFrames (no individual IDs; no marker IDs (header))
 """
-    get_genotypes(file::Union{AbstractString,Array{Float64,2},Array{Float32,2},Array{Any,2},DataFrames.DataFrame},G=false;
-                  separator=',',header=true,rowID=false,
-                  center=true,quality_control=false,
-                  method = "RR-BLUP",Pi = 0.0,estimatePi = true,estimate_scale=false,estimate_variance=true,
-                  G_is_marker_variance = false,df = 4.0)
+get_genotypes(file::Union{AbstractString,Array{Float64,2},Array{Float32,2},Array{Int64,2}, Array{Int32,2}, Array{Any,2}, DataFrames.DataFrame}, G = false;
+            ## method:
+            method = "BayesC",Pi = 0.0,estimatePi = true, 
+            ## variance:
+            G_is_marker_variance = false, df = 4.0,
+            estimate_variance=true, estimate_scale=false,
+            constraint = false, #for multi-trait only, constraint=true means no genetic covariance among traits
+            ## format:
+            separator=',',header=true,rowID=false,
+            ## quality control:
+            quality_control=true, MAF = 0.01, missing_value = 9.0,
+            ## others:
+            center=true,starting_value=false)
 * Get marker informtion from a genotype file/matrix. This file needs to be column-wise sorted by marker positions.
     * If a text file is provided, the file format should be:
       ```
@@ -82,62 +92,62 @@ end
 * Scale parameter for prior of marker effect variance is estimated if `estimate_scale` = true, defaulting to `false`.
 
 """
-function get_genotypes(file::Union{AbstractString,Array{Float64,2},Array{Float32,2},Array{Any,2},DataFrames.DataFrame},G=false;
+function get_genotypes(file::Union{AbstractString,Array{Float64,2},Array{Float32,2},Array{Int64,2}, Array{Int32,2}, Array{Any,2}, DataFrames.DataFrame}, G = false;
                        ## method:
-                       method = "BayesC",Pi = 0.0,estimatePi = true, 
+                       method = "BayesC", Pi = 0.0, estimatePi = true, 
                        ## variance:
                        G_is_marker_variance = false, df = 4.0,
-                       estimate_variance=true, estimate_scale=false,
+                       estimate_variance = true, estimate_scale = false,
                        constraint = false, #for multi-trait only, constraint=true means no genetic covariance among traits
                        ## format:
-                       separator=',',header=true,rowID=false,
+                       separator = ',', header = true,
                        ## quality control:
-                       quality_control=true, MAF = 0.01, missing_value = 9.0,
+                       quality_control = true, MAF = 0.01, missing_value = 9.0,
                        ## others:
-                       center=true,starting_value=false)
+                       center = true, starting_value = false)
     #Read the genotype file
-    if typeof(file) <: AbstractString
-        printstyled("The delimiterd in ",split(file,['/','\\'])[end]," is \'",separator,"\'. ",bold=false,color=:green)
-        printstyled("The header (marker IDs) is ",(header ? "provided" : "not provided")," in ",split(file,['/','\\'])[end],".\n",bold=false,color=:green)
+    if typeof(file) <: AbstractString  #string (path to a file)
+        #print info about the file format
+        printstyled("The delimiter in ", split(file, ['/', '\\'])[end], " is \'", separator, "\'. ", bold=false, color=:green)
+        printstyled("The header (marker IDs) is ", (header ? "provided" : "not provided"), " in ", split(file, ['/', '\\'])[end], ".\n", bold=false, color=:green)
         #get marker IDs
         myfile = open(file)
-        row1   = split(readline(myfile),[separator,'\n'],keepempty=false)
-        if header==true
-            markerID=string.(row1[2:end])  #skip header
+        row1   = split(readline(myfile), [separator, '\n'], keepempty=false) #read the first row
+        if header == true
+            markerID = string.(row1[2:end])           #extracts marker IDs from row1
         else
-            markerID=string.(1:length(row1[2:end]))
+            markerID = string.(1:length(row1[2:end])) #generate default marker IDs if no header
         end
         #set type for each column
-        ncol= length(row1)
-        etv = Array{DataType}(undef,ncol)
-        fill!(etv,Float64)
-        etv[1]=String
+        ncol = length(row1)
+        etv  = Array{DataType}(undef, ncol)
+        fill!(etv, Float32)
+        etv[1] = String #individual ID
         close(myfile)
         #read a large genotype file
         data      = CSV.read(file,DataFrame,types=etv,delim = separator,header=false,skipto=(header==true ? 2 : 1))
         obsID     = map(string,data[!,1])
-        genotypes = map(Float32,Matrix(data[!,2:end]))
+        genotypes = Matrix{Float32}(data[!,2:end]) #memory usage is doubled here; cannot use readdlm because 1st column is string
+        #clean memory
+        data = nothing
+        GC.gc()
     elseif typeof(file) == DataFrames.DataFrame #Datafarme
         println("The first column in the dataframe should be individual IDs.")
-        println("The data type of markers should be Number.")
+        println("The remaining columns are markers with the data type Number.")
         if header == true
             markerID = names(file)[2:end]
         else
             markerID = string.(1:(size(file,2)-1))
+            printstyled("The marker IDs are set to 1,2,...,#markers\n",bold=true)
         end
         obsID     = map(string,file[!,1])
         genotypes = map(Float32,Matrix(file[!,2:end]))
-    elseif typeof(file) <: Union{Array{Float64,2},Array{Float32,2},Array{Any,2}} #Array
-        if length(header) != (size(file,2)+1)
-            header = ["id"; string.(1:size(file,2))]
-            printstyled("The marker IDs are set to 1,2,...,#markers\n",bold=true)
-        end
-        if length(rowID) != size(file,1)
-            rowID = string.(1:size(file,1))
-            printstyled("The individual IDs is set to 1,2,...,#observations\n",bold=true)
-        end
-        markerID  = string.(header[2:end])
-        obsID     = map(string,rowID)
+    elseif typeof(file) <: Union{Array{Float64,2}, Array{Float32,2}, Array{Int64,2}, Array{Int32,2}, Array{Any,2}} #Array (Matrix)
+        println("The input data is a genotype matrix, without individual IDs.")
+        markerID  = string.(1:size(file,2))
+        printstyled("The marker IDs are set to 1,2,...,#markers\n",bold=true)
+        obsID     = map(string,string.(1:size(file,1)))
+        printstyled("The individual IDs is set to 1,2,...,#observations\n",bold=true)
         genotypes = map(Float32,convert(Matrix,file))
     else
         error("The data type is not supported.")

--- a/src/1.JWAS/src/markers/readgenotypes.jl
+++ b/src/1.JWAS/src/markers/readgenotypes.jl
@@ -51,34 +51,39 @@ end
 #
 ################################################################################
 #1)load genotypes from a text file (1st column: individual IDs; 1st row: marker IDs (optional))
-#2)load genotypes from Array or DataFrames (no individual IDs; no marker IDs (header))
+#2)load genotypes from DataFrames (1st column: individual IDs; optional: marker IDs (can be provided as the header))
+#3)load genotypes from Array (User-provided Individual IDs and marker IDs are not allowed, defaulting to 1,2,3...)
 """
-get_genotypes(file::Union{AbstractString,Array{Float64,2},Array{Float32,2},Array{Int64,2}, Array{Int32,2}, Array{Any,2}, DataFrames.DataFrame}, G = false;
-            ## method:
-            method = "BayesC",Pi = 0.0,estimatePi = true, 
-            ## variance:
-            G_is_marker_variance = false, df = 4.0,
-            estimate_variance=true, estimate_scale=false,
-            constraint = false, #for multi-trait only, constraint=true means no genetic covariance among traits
-            ## format:
-            separator=',',header=true,rowID=false,
-            ## quality control:
-            quality_control=true, MAF = 0.01, missing_value = 9.0,
-            ## others:
-            center=true,starting_value=false)
+    get_genotypes(file::Union{AbstractString,Array{Float64,2},Array{Float32,2},Array{Int64,2}, Array{Int32,2}, Array{Any,2}, DataFrames.DataFrame}, G = false;
+                  ## method:
+                  method = "BayesC",Pi = 0.0,estimatePi = true, 
+                  ## variance:
+                  G_is_marker_variance = false, df = 4.0,
+                  estimate_variance=true, estimate_scale=false,
+                  constraint = false, #for multi-trait only, constraint=true means no genetic covariance among traits
+                  ## format:
+                  separator=',',header=true,
+                  ## quality control:
+                  quality_control=true, MAF = 0.01, missing_value = 9.0,
+                  ## others:
+                  center=true,starting_value=false)
 * Get marker informtion from a genotype file/matrix. This file needs to be column-wise sorted by marker positions.
-    * If a text file is provided, the file format should be:
-      ```
-      Animal,marker1,marker2,marker3,marker4,marker5
-      S1,1,0,1,1,1
-      D1,2,0,2,2,1
-      O1,1,2,0,1,0
-      O3,0,0,2,1,1
-      ```
-    * If an nxp Matrix of genotypes (Array or DataFrame) is provided, where n is the number of individuals and p is the number of markers,
-        * This matrix needs to be column-wise sorted by marker positions.
-        * rowID is a vector of individual IDs, e.g.,rowID=[\"a1\",\"b2\",\"c1\"]; if it is omitted, IDs will be set to 1:n
-        * header is a header vector such as ["id"; "mrk1"; "mrk2";...;"mrkp"]. If omitted, marker names will be set to 1:p
+* If `a text file` is provided, the file format should be:
+```
+Animal,marker1,marker2,marker3,marker4,marker5
+S1,1,0,1,1,1
+D1,2,0,2,2,1
+O1,1,2,0,1,0
+O3,0,0,2,1,1
+```
+* If `a DataFrame` is provided, where n is the number of individuals and p is the number of markers,
+    * This matrix needs to be column-wise sorted by marker positions.
+    * The first column in the DataFrame should be individual IDs
+    * The marker IDs can be provided as the header of the DataFrame. If omitted, marker IDs will be set to 1,2,3...
+* If `an nxp Matrix` of genotypes (Array) is provided, where n is the number of individuals and p is the number of markers,
+    * This matrix needs to be column-wise sorted by marker positions.
+    * Individual IDs will be set to 1:n; 
+    * Marker IDs will be set to 1:p
 * If `quality_control`=true, defaulting to `true`,
     * Missing genotypes should be denoted as `9`, and will be replaced by column means. Users can also impute missing genotypes before the analysis.
     * Minor allele frequency `MAF` threshold, defaulting to `0.01`, is uesd, and fixed loci are removed.
@@ -143,7 +148,7 @@ function get_genotypes(file::Union{AbstractString,Array{Float64,2},Array{Float32
         obsID     = map(string,file[!,1])
         genotypes = map(Float32,Matrix(file[!,2:end]))
     elseif typeof(file) <: Union{Array{Float64,2}, Array{Float32,2}, Array{Int64,2}, Array{Int32,2}, Array{Any,2}} #Array (Matrix)
-        println("The input data is a genotype matrix, without individual IDs.")
+        println("The input data is a genotype matrix, without individual IDs and marker IDs.")
         markerID  = string.(1:size(file,2))
         printstyled("The marker IDs are set to 1,2,...,#markers\n",bold=true)
         obsID     = map(string,string.(1:size(file,1)))

--- a/src/1.JWAS/src/markers/readgenotypes.jl
+++ b/src/1.JWAS/src/markers/readgenotypes.jl
@@ -105,11 +105,13 @@ function get_genotypes(file::Union{AbstractString,Array{Float64,2},Array{Float32
                        estimate_variance = true, estimate_scale = false,
                        constraint = false, #for multi-trait only, constraint=true means no genetic covariance among traits
                        ## format:
-                       separator = ',', header = true,
+                       separator = ',', header = true, double_precision = false,
                        ## quality control:
                        quality_control = true, MAF = 0.01, missing_value = 9.0,
                        ## others:
                        center = true, starting_value = false)
+    #Define data precision
+    data_type = double_precision ? Float64 : Float32 #works for both genotypes and GRM
     #Read the genotype file
     if typeof(file) <: AbstractString  #string (path to a file)
         #print info about the file format
@@ -126,16 +128,19 @@ function get_genotypes(file::Union{AbstractString,Array{Float64,2},Array{Float32
         #set type for each column
         ncol = length(row1)
         etv  = Array{DataType}(undef, ncol)
-        fill!(etv, Float32)
+        fill!(etv, data_type)
         etv[1] = String #individual ID
         close(myfile)
         #read a large genotype file
         data      = CSV.read(file,DataFrame,types=etv,delim = separator,header=false,skipto=(header==true ? 2 : 1))
         obsID     = map(string,data[!,1])
-        genotypes = Matrix{Float32}(data[!,2:end]) #memory usage is doubled here; cannot use readdlm because 1st column is string
+        genotypes = Matrix(data[!,2:end]) #memory usage is doubled here
         #clean memory
         data = nothing
         GC.gc()
+        #Note: why we choose to use `genotypes = Matrix(data[!,2:end])`
+         #- cannot use `genotypes=@view data[!,2:end]` because the view will be copied as a new DataFrame in QC: `genotypes = genotypes[:,select]`
+         #- cannot use `select!(genotypes, Not(1))` to simply delete the 1st column of obsID from the DataFrame, because genotypes must be a Matrix used for matrix multiplication (e.g. EBV += Mi.output_genotypes*Mi.α[traiti]).
     elseif typeof(file) == DataFrames.DataFrame #Datafarme
         println("The first column in the dataframe should be individual IDs.")
         println("The remaining columns are markers with the data type Number.")
@@ -146,14 +151,14 @@ function get_genotypes(file::Union{AbstractString,Array{Float64,2},Array{Float32
             printstyled("The marker IDs are set to 1,2,...,#markers\n",bold=true)
         end
         obsID     = map(string,file[!,1])
-        genotypes = map(Float32,Matrix(file[!,2:end]))
+        genotypes = map(data_type, Matrix(file[!,2:end]))
     elseif typeof(file) <: Union{Array{Float64,2}, Array{Float32,2}, Array{Int64,2}, Array{Int32,2}, Array{Any,2}} #Array (Matrix)
         println("The input data is a genotype matrix, without individual IDs and marker IDs.")
         markerID  = string.(1:size(file,2))
         printstyled("The marker IDs are set to 1,2,...,#markers\n",bold=true)
         obsID     = map(string,string.(1:size(file,1)))
         printstyled("The individual IDs is set to 1,2,...,#observations\n",bold=true)
-        genotypes = map(Float32,convert(Matrix,file))
+        genotypes = map(data_type, convert(Matrix,file))
     else
         error("The data type is not supported.")
     end
@@ -191,7 +196,7 @@ function get_genotypes(file::Union{AbstractString,Array{Float64,2},Array{Float32
     end
 
     markerMeans   = center==true ? center!(genotypes) : mean(genotypes,dims=1) #centering genotypes or not
-    p             = markerMeans/2.0       #allele frequency
+    p             = markerMeans/data_type(2.0)       #allele frequency
 
     #Naive Quality Control 2, minor allel frequency & fixed loci
     if quality_control == true
@@ -210,14 +215,14 @@ function get_genotypes(file::Union{AbstractString,Array{Float64,2},Array{Float32
     if method == "GBLUP"
         if !isGRM #calculate the relationship matrix from the genotype covariate matrix
             genotypes  = genotypes ./ sqrt.(2*p.*(1 .- p))
-            genotypes  = (genotypes*genotypes'+ I*0.00001)/nMarkers
+            genotypes  = (genotypes*genotypes'+ I*data_type(0.00001))/nMarkers
             println("A genomic relationship matrix is computed from genotypes.")
             isGRM  = true
         end
         add_small_value_count = 0
         while isposdef(genotypes) == false
             println("The relationship matrix is not positive definite. A very small number is added to the diagonal.")
-            genotypes = genotypes + I*0.00001
+            genotypes = genotypes + I*data_type(0.00001)
             add_small_value_count += 1
             if add_small_value_count > 10
                 error("Please provide a positive-definite relationship matrix.")

--- a/src/1.JWAS/src/markers/tools4genotypes.jl
+++ b/src/1.JWAS/src/markers/tools4genotypes.jl
@@ -74,7 +74,7 @@ function align_genotypes(mme::MME,output_heritability=false,single_step_analysis
                     Zo  = map(Float32,mkmat_incidence_factor(mme.output_ID,Mi.obsID))
                     Mi.output_genotypes =  Zo*Mi.genotypes
                 else
-                    Mi.output_genotypes =  Mi.genotypes #why this is a copy
+                    Mi.output_genotypes =  Mi.genotypes #reference, not copy
                 end
                 if Mi.isGRM #relationship matrix is provided
                     Z  = map(Float32,mkmat_incidence_factor(mme.obsID,Mi.obsID))


### PR DESCRIPTION
1. delete `rowID=false` in the arguments of `get_genotypes()` function, because this is only used for matrix input. For internal testing, better to use a Dataframe as input.
2. when set type for each column, use Float32, instead of Float64 in line`fill!(etv,Float32)`.
3. for string input (i.e., path), add code to clean the memory of the `data` variable:
    ```
    data = nothing
    GC.gc()
    ```
    here we cannot read the matrix directly form path, because the 1st column is string.
5. clean code for matrix input
6. for matrix input, also allow Array{Int64,2}, Array{Int32,2} as input
7. add some comments
8. improve some format
9. add argument `double_precision` which works for both genotypes and GRM.
10. improve documentation
11. add a comment to explain why we still choose to use `genotypes = Matrix(data[!,2:end])`.

Testing code:
```{julia}
using JWAS,DataFrames,CSV,Statistics,JWAS.Datasets

#file path
genofile   = dataset("genotypes.csv")
genotypes  = get_genotypes(genofile,separator=',',method="BayesC");
genotypes.genotypes #Matrix{Float32}

#dataframe
df=CSV.read(genofile,DataFrame)
genotypes  = get_genotypes(df,separator=',',method="BayesC");
genotypes.genotypes

#matrix
ma=Matrix(CSV.read(genofile,DataFrame)[!,2:end])
genotypes  = get_genotypes(ma,separator=',',method="BayesC");
genotypes.genotypes #Matrix{Float32}
```