### PR TITLE
fix two bug due to datatype (Float32 or Float 64) and the variance module

### DIFF
--- a/src/1.JWAS/src/single_step/SSBR.jl
+++ b/src/1.JWAS/src/single_step/SSBR.jl
@@ -30,7 +30,7 @@ function SSBRrun(mme,df_whole,train_index,big_memory=false)
         df_whole[!,Symbol("J")],mme.output_X["J"]=make_JVecs(mme,df_whole,Ai_nn,Ai_ng)
         set_covariate(mme,"J")
     end
-    set_random(mme,"ϵ",geno.genetic_variance,Vinv=Ai_nn,names=ped.IDs[1:size(Ai_nn,1)])
+    set_random(mme,"ϵ",geno.genetic_variance.val,Vinv=Ai_nn,names=ped.IDs[1:size(Ai_nn,1)])
     #trick to avoid errors (PedModule.getIDs(ped) [nongeno ID;geno ID])
     mme.output_X["ϵ"]=mkmat_incidence_factor(mme.output_ID,ped.IDs)[:,1:size(Ai_nn,1)]
 
@@ -73,6 +73,7 @@ end
 # Genotypes
 ############################################################################
 function impute_genotypes(geno,ped,mme,Ai_nn,Ai_ng,df,big_memory=false)
+    data_type = typeof(geno.genotypes[1,1]) #e.g. Float32
     num_pedn = size(Ai_nn,1)
     #reorder genotypes to get Mg with the same order as Ai_gg
     Z  = mkmat_incidence_factor(ped.IDs[(num_pedn+1):end],geno.obsID)
@@ -125,8 +126,8 @@ function impute_genotypes(geno,ped,mme,Ai_nn,Ai_ng,df,big_memory=false)
          Mout   = Zo*(lhs\(rhs*Mg))
     end
 
-    geno.output_genotypes = Mout
-    geno.genotypes        = Mpheno
+    geno.output_genotypes = data_type.(Mout) #make datatype consistant to avoid error here: BLAS.axpy!(oldAlpha-α[j],x,yCorr)
+    geno.genotypes        = data_type.(Mpheno)
     geno.obsID            = df[!,1]
     geno.nObs             = length(geno.obsID)
     GC.gc()


### PR DESCRIPTION
fixed two bugs for single-step:
1. use `geno.genetic_variance.val` instead of `geno.genetic_variance` because now it is the Variance struct.
2. in `impute_genotypes()`, make sure the data type (Float32 or Float64) of genotypes is unchanged after imputation. Otherwise the `impute_genotypes()` will only create Float64 genotype matrix, and this will cause an error for `BLAS.axpy!(oldAlpha-α[j],x,yCorr)` when x is Float64 but yCorr is Float32.