### PR TITLE
fix println in nnmm due to remove of a function; fix G.val; set starting val for multiple binary traits to I

### DIFF
--- a/src/1.JWAS/src/Nonlinear/nnbayes_check.jl
+++ b/src/1.JWAS/src/Nonlinear/nnbayes_check.jl
@@ -208,6 +208,7 @@ end
 
 
 function nnmm_print_info_input_to_middle_layer(mme)
+        nThread = Threads.nthreads()
         is_mega_trait = mme.R.constraint==true && mme.M[1].G.constraint==true #is_mega_trait when no residual and marker effect covariances 
         if is_mega_trait
             printstyled(" - Bayesian Alphabet:                multiple independent single-trait Bayesian models are used to sample marker effect. \n",bold=false,color=:green)

--- a/src/1.JWAS/src/markers/BayesianAlphabet/BayesC0L.jl
+++ b/src/1.JWAS/src/markers/BayesianAlphabet/BayesC0L.jl
@@ -1,25 +1,25 @@
 function megaBayesL!(genotypes,wArray,vare)
     Threads.@threads for i in 1:length(wArray) #ntraits
         BayesL!(genotypes.mArray,genotypes.mRinvArray,genotypes.mpRinvm,
-            wArray[i],genotypes.α[i],genotypes.gammaArray,vare[i,i],genotypes.G[i,i])
+            wArray[i],genotypes.α[i],genotypes.gammaArray,vare[i,i],genotypes.G.val[i,i])
     end
 end
 
 function BayesL!(genotypes,ycorr,vare)
     BayesL!(genotypes.mArray,genotypes.mRinvArray,genotypes.mpRinvm,
-            ycorr,genotypes.α[1],genotypes.gammaArray,vare,genotypes.G)
+            ycorr,genotypes.α[1],genotypes.gammaArray,vare,genotypes.G.val)
 end
 
 function megaBayesC0!(genotypes,wArray,vare)
     Threads.@threads for i in 1:length(wArray) #ntraits
         BayesL!(genotypes.mArray,genotypes.mRinvArray,genotypes.mpRinvm,
-                wArray[i],genotypes.α[i],[1.0],vare[i,i],genotypes.G[i,i])
+                wArray[i],genotypes.α[i],[1.0],vare[i,i],genotypes.G.val[i,i])
     end
 end
 
 function BayesC0!(genotypes,ycorr,vare)
     BayesL!(genotypes.mArray,genotypes.mRinvArray,genotypes.mpRinvm,
-            ycorr,genotypes.α[1],[1.0],vare,genotypes.G)
+            ycorr,genotypes.α[1],[1.0],vare,genotypes.G.val)
 end
 
 function BayesL!(xArray,xRinvArray,xpRinvx,


### PR DESCRIPTION
* fix printing error in nnmm. The error is because we wrap those codes from `runMCMC()` into a function, and the `nThread` is missing.
* change G to G.val in BayesL
* fix the starting value for R to identity matrix when all traits are binary (old code: the R will only be fixed to the identity matrix during sampling)