### PR TITLE
update GWAS: fixed data type for 2nd and 3rd column when read mapfile.

### DIFF
--- a/src/1.JWAS/src/markers/BayesianAlphabet/MTBayesC0L.jl
+++ b/src/1.JWAS/src/markers/BayesianAlphabet/MTBayesC0L.jl
@@ -1,11 +1,11 @@
 function MTBayesL!(genotypes,ycorr_array,vare)
     MTBayesL!(genotypes.mArray,genotypes.mRinvArray,genotypes.mpRinvm,
-            ycorr_array,genotypes.α,genotypes.gammaArray,vare,genotypes.G)
+            ycorr_array,genotypes.α,genotypes.gammaArray,vare,genotypes.G.val)
 end
 
 function MTBayesC0!(genotypes,ycorr_array,vare)
     MTBayesL!(genotypes.mArray,genotypes.mRinvArray,genotypes.mpRinvm,
-            ycorr_array,genotypes.α,[1.0],vare,genotypes.G)
+            ycorr_array,genotypes.α,[1.0],vare,genotypes.G.val)
 end
 
 function MTBayesL!(xArray,xRinvArray,xpRinvx,

--- a/src/3.GWAS/src/GWAS.jl
+++ b/src/3.GWAS/src/GWAS.jl
@@ -76,7 +76,7 @@ function GWAS(mme,map_file,marker_effects_file::AbstractString...;
     end
 
     window_size_bp = map(Int64,parse(Float64,split(window_size)[1])*1_000_000)
-    mapfile = CSV.read(map_file, DataFrame, header = header, types=Dict(1 => String)) #the 1st column (markerID) must be string
+    mapfile = CSV.read(map_file, DataFrame, header = header, types=Dict(1 => String, 2 => String, 3 => Int64)) #the 1st column (markerID) must be string
     #remove SNPs in mapfile that are not used in Bayesian analysis (e.g., removed in QC)
     snpID    = mme.M[1].markerID
     in_snpID = findall(x -> x ∈ snpID, mapfile[:,1])
@@ -85,8 +85,8 @@ function GWAS(mme,map_file,marker_effects_file::AbstractString...;
         error("Please check the 1st column of the mapfile (i.e., marker ID)")
     end
     
-    chr     = map(string,mapfile[:,2])
-    pos     = map(Int64,mapfile[:,3])
+    chr     = mapfile[:,2]
+    pos     = mapfile[:,3]
 
     window_size_nSNPs   = Array{Int64,1}()  #save number of markers in ith window for all windows
     window_chr          = Array{String,1}() #1


### PR DESCRIPTION
Fixed data type for 2nd and 3rd column when read mapfile.

Reason: user reported that old code `mapfile = CSV.read(map_file, DataFrame, header = header, types=Dict(1 => String))` converts the 3rd column to a crazy type of `::SentinelArrays.ChainedVector{Float64, Vector{Float64}})`. This will cause error for this line in GWAS(): `map(Int64,mapfile[:,3])`. 

The new code solves the issue. New code: `mapfile = CSV.read(map_file, DataFrame, header = header, types=Dict(1 => String, 2 => String, 3 => Int64))`


Other modification:
old code:
```
    chr     = map(string,mapfile[:,2])
    pos     = map(Int64,mapfile[:,3])
```
new code:
```
    chr     = mapfile[:,2]
    pos     = mapfile[:,3]
```