### PR TITLE
remove redundent code due to interface change

### DIFF
--- a/src/1.JWAS/src/input_data_validation.jl
+++ b/src/1.JWAS/src/input_data_validation.jl
@@ -167,9 +167,6 @@ function check_pedigree_genotypes_phenotypes(mme,df,pedigree)
         if !issubset(phenoID,pedID)
             index = [phenoID[i] in pedID for i=1:length(phenoID)]
             df    = df[index,:]
-            if mme.MCMCinfo.censored_trait != false
-                mme.MCMCinfo.censored_trait = mme.MCMCinfo.censored_trait[index]
-            end
             printstyled("In this incomplete genomic data (single-step) or PBLUP analysis, ",
             length(index)-sum(index)," phenotyped individuals are not included in the pedigree. ",
             "These are removed from the analysis.\n",bold=false,color=:red)


### PR DESCRIPTION
These three lines 
```
            if mme.MCMCinfo.censored_trait != false
                mme.MCMCinfo.censored_trait = mme.MCMCinfo.censored_trait[index]
            end
```
should be removed due to a change in the interface for the censored trait. The `mme.MCMCinfo.censored_trait` is removed and now `mme.traits_type` is used.

Otherwise will cause an error when `if !issubset(phenoID,pedID)` is true.