### PR TITLE
fix single-step inline ID handling

### DIFF
--- a/src/1.JWAS/src/single_step/SSBR.jl
+++ b/src/1.JWAS/src/single_step/SSBR.jl
@@ -22,7 +22,7 @@ function SSBRrun(mme,df_whole,train_index,big_memory=false)
     end
     #add data for ϵ and J (add columns in input phenotypic data)
     isnongeno = [ID in mme.ped.setNG for ID in df_whole[!,1]] #true/false
-    data_ϵ    = deepcopy(df_whole[!,1])
+    data_ϵ    = String.(df_whole[!,1])
     data_ϵ[.!isnongeno].="missing"
     df_whole[!,Symbol("ϵ")]=data_ϵ
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -116,6 +116,10 @@ println()
             include(joinpath(@__DIR__, "unit", "test_input_validation.jl"))
         end
 
+        @testset "Single-step Analysis" begin
+            include(joinpath(@__DIR__, "unit", "test_single_step.jl"))
+        end
+
         @testset "Multi-trait MCMC" begin
             include(joinpath(@__DIR__, "unit", "test_multitrait_mcmc.jl"))
         end

--- a/test/unit/test_single_step.jl
+++ b/test/unit/test_single_step.jl
@@ -1,0 +1,40 @@
+# Unit tests for single-step analysis regressions
+using Test, JWAS, DataFrames, CSV, JWAS.Datasets
+
+@testset "Single-step analysis" begin
+    phenofile = Datasets.dataset("phenotypes.txt", dataset_name="demo_7animals")
+    pedfile = Datasets.dataset("pedigree.txt", dataset_name="demo_7animals")
+    genofile = Datasets.dataset("genotypes.txt", dataset_name="demo_7animals")
+
+    phenotypes = CSV.read(phenofile, DataFrame, delim=',', missingstring=["NA"])
+    pedigree = get_pedigree(pedfile, separator=',', header=true)
+
+    @testset "BayesC accepts CSV inline-string IDs" begin
+        output_folder = "test_single_step_inline_ids"
+        isdir(output_folder) && rm(output_folder, recursive=true, force=true)
+        global genotypes = get_genotypes(genofile, separator=',', method="BayesC")
+        model = build_model("y1 = intercept + genotypes")
+
+        local output
+        try
+            output = runMCMC(
+                model,
+                phenotypes;
+                single_step_analysis=true,
+                pedigree=pedigree,
+                chain_length=2,
+                output_samples_frequency=1,
+                output_heritability=false,
+                printout_model_info=false,
+                output_folder=output_folder,
+                seed=160,
+            )
+
+            @test haskey(output, "EBV_y1")
+            @test eltype(model.M[1].genotypes) == Float32
+            @test eltype(model.M[1].output_genotypes) == Float32
+        finally
+            isdir(output_folder) && rm(output_folder, recursive=true, force=true)
+        end
+    end
+end


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches single-step SSBR data preparation by changing how individual IDs are materialized for the imputation residual term; incorrect coercion could still break downstream incidence matrices. Added a small regression test to catch failures, reducing overall risk.
> 
> **Overview**
> Fixes single-step SSBR handling of “inline” (CSV-read) individual IDs by explicitly coercing the first phenotype column to `String` when constructing the imputation-residual (`ϵ`) factor, instead of `deepcopy`ing the original ID vector.
> 
> Adds a new unit regression test (`test_single_step.jl`) and wires it into `runtests.jl` to ensure a short `runMCMC(...; single_step_analysis=true)` run completes and produces `EBV_y1` when IDs are parsed as strings, while preserving `Float32` genotype buffers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcb3cbd4f6fbd4dd03b241e55ae8180cbde69ad8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->